### PR TITLE
Corrections to make unittests work again in travis without a pre-compiled jar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,8 @@ before_script:
  - mvn package
 script:
  - py.test
-# travis core dumped
-# - mvn test -DdryRun=true -DcoverallsFile=java_coverage.json jacoco:report coveralls:report
+ #- tests/integration_test.sh
+ - mvn test -DdryRun=true -DcoverallsFile=java_coverage.json jacoco:report coveralls:report
 after_success:
-# - coverage combine
-# - coveralls --merge=java_coverage.json
-  - coveralls
+ - coverage combine
+ - coveralls --merge=java_coverage.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
 before_install:
  - sudo apt-get update
  - sudo apt-get install libxml2-dev libxslt1-dev
- - sudo apt-get install openjdk-7-jdk-headless
+ - sudo apt-get install openjdk-7-jdk icedtea-7-plugin
  - sudo apt-get install maven
  - export JAVA_HOME=/usr/lib/jvm/java-7-openjdk-amd64/
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,18 @@
 language: python
 python:
  - "2.7"
+addons:
+  # Required to avoid Java 7 openjdk buffer overflow:
+  # https://github.com/travis-ci/travis-ci/issues/5227#issuecomment-165131913
+  hosts:
+    - myshorthost
+  hostname: myshorthost
 before_install:
  - sudo apt-get update
  - sudo apt-get install libxml2-dev libxslt1-dev
- - sudo apt-get install openjdk-8-jdk-headless
+ - sudo apt-get install openjdk-7-jdk-headless
  - sudo apt-get install maven
- - export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/
+ - export JAVA_HOME=/usr/lib/jvm/java-7-openjdk-amd64/
 install:
  - pip install --upgrade setuptools
  - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,10 @@ python:
  - "2.7"
 before_install:
  - sudo apt-get update
- - sudo apt-get install openjdk-7-jdk icedtea-7-plugin libxml2-dev libxslt1-dev
- - export JAVA_HOME=/usr/lib/jvm/java-7-openjdk-amd64/
+ - sudo apt-get install libxml2-dev libxslt1-dev
+ - sudo apt-get install openjdk-8-jdk-headless
+ - sudo apt-get install maven
+ - export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/
 install:
  - pip install --upgrade setuptools
  - pip install -r requirements.txt
@@ -12,10 +14,11 @@ install:
 services:
  - rabbitmq
 before_script:
- - sudo rabbitmqctl add_vhost adsfulltext
- - sudo rabbitmqctl add_vhost external_vhost
- - sudo rabbitmqctl set_permissions -p adsfulltext guest ".*" ".*" ".*"
- - sudo rabbitmqctl set_permissions -p external_vhost guest ".*" ".*" ".*"
+ - sudo rabbitmqctl add_vhost fulltext_pipeline
+ - sudo rabbitmqctl add_vhost master_pipeline
+ - sudo rabbitmqctl set_permissions -p fulltext_pipeline guest ".*" ".*" ".*"
+ - sudo rabbitmqctl set_permissions -p master_pipeline guest ".*" ".*" ".*"
+ - mvn package
 script:
  - py.test
 # travis core dumped

--- a/adsft/tasks.py
+++ b/adsft/tasks.py
@@ -4,10 +4,12 @@ import adsft.app as app_module
 from adsputils import get_date, exceptions
 from kombu import Queue
 from adsft import extraction, checker, writer
+import os
 
 # ============================= INITIALIZATION ==================================== #
 
-app = app_module.ADSFulltextCelery('ads-fulltext')
+proj_home = os.path.realpath(os.path.join(os.path.dirname(__file__), '../'))
+app = app_module.ADSFulltextCelery('ads-fulltext', proj_home=proj_home)
 logger = app.logger
 
 

--- a/adsft/tests/test_base.py
+++ b/adsft/tests/test_base.py
@@ -137,7 +137,7 @@ class TestUnit(unittest.TestCase):
         unittest.TestCase.setUp(self)
         self.proj_home = os.path.realpath(os.path.join(os.path.dirname(__file__), '../..'))
         self._app = tasks.app
-        self.app = app.ADSFulltextCelery('test', local_config=\
+        self.app = app.ADSFulltextCelery('test', proj_home=self.proj_home, local_config=\
             {
             'FULLTEXT_EXTRACT_PATH': os.path.join(self.proj_home, 'tests/test_unit/stub_data'),
             'CELERY_BROKER': tasks.app.conf['CELERY_BROKER'] + '_test'

--- a/adsft/tests/test_tasks.py
+++ b/adsft/tests/test_tasks.py
@@ -13,7 +13,7 @@ class TestWorkers(unittest.TestCase):
         unittest.TestCase.setUp(self)
         self.proj_home = tasks.app.conf['PROJ_HOME']
         self._app = tasks.app
-        self.app = app.ADSFulltextCelery('test', local_config=\
+        self.app = app.ADSFulltextCelery('test', proj_home=self.proj_home, local_config=\
             {
             })
         tasks.app = self.app # monkey-patch the app object

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>org.apache.pdfbox</groupId>
       <artifactId>pdfbox</artifactId>
-      <version>1.8.8</version>
+      <version>1.8.13</version>
     </dependency>
 
     <dependency>

--- a/scripts/extract_pdf.sh
+++ b/scripts/extract_pdf.sh
@@ -6,7 +6,7 @@
 
 java=java
 home=`dirname "$BASH_SOURCE"`
-jar=$home/ADSfulltext-1.2-SNAPSHOT-jar-with-dependencies.jar
+jar=$home/../target/ADSfulltext-1.2-SNAPSHOT-jar-with-dependencies.jar
 input=$0
 
 #echo "java=$java home=$home jar=$jar input=$input"


### PR DESCRIPTION
I have reverted PR #39 removing the jar from the repository and implementing a workaround to avoid the Travis Java buffer overflow problem.

There is also a small correction to specify the project home path (via the Celery app), otherwise tests were not running on my machine.