### PR TITLE
Unicode ascii encoding error

### DIFF
--- a/adsft/writer.py
+++ b/adsft/writer.py
@@ -42,9 +42,9 @@ def write_to_temp_file(payload, temp_path='/tmp/', json_format=True):
             json.dump(payload, temp_file)
         else:
             if type(payload) == unicode:
-                temp_file.write(payload)
-            else:
                 temp_file.write(payload.encode('utf-8'))
+            else:
+                temp_file.write(payload) # assuming this is already a bytecode
 
     logger.debug('Temp file name: {0}'.format(temp_file_name))
 


### PR DESCRIPTION
I believe the logic is reversed here; the bytecode is already there - and needs only to be encoded in case of unicode (by default, python would use ascii - on my machine, it probably uses utf-8, as i can't reproduce it)