### PR TITLE
#65 partial support for multi-file fulltext records

### DIFF
--- a/adsft/checker.py
+++ b/adsft/checker.py
@@ -225,6 +225,8 @@ def check_if_extract(message_list, extract_path):
             logger.debug('No existing meta file')
             update = 'NOT_EXTRACTED_BEFORE'
 
+        # clobber muliple filenames, replace with first
+        message['ft_source'] = filename_cleanup(message['ft_source'])
         if os.path.exists(message['ft_source']):
             ft_source_size = os.stat(message['ft_source']).st_size # bytes
             if ft_source_size == 0:
@@ -268,3 +270,10 @@ def check_if_extract(message_list, extract_path):
 
     return {'Standard': publish_list_of_standard_dictionaries,
             'PDF': publish_list_of_pdf_dictionaries}
+
+def filename_cleanup(filename):
+    """if multiple filenames, return only first"""
+    clean = filename
+    if clean and ',/' in clean:
+        clean = clean[:clean.find(',/')]
+    return clean

--- a/adsft/tests/test_checker.py
+++ b/adsft/tests/test_checker.py
@@ -340,7 +340,34 @@ class TestCheckIfExtracted(test_base.TestUnit):
         self.assertTrue(first_doc_false['UPDATE'],
                         'DIFFERING_FULL_TEXT')
         self.assertTrue(len(payload_false['PDF']) != 0)
-            
+
+    def test_filename_cleanup(self):
+        """check code that deals with multiple files for bibcode"""
+
+        file = '/foo/bar.pdf'
+        clean = checker.filename_cleanup(file)
+        self.assertEqual(file, clean)
+
+        file = '/foo/ba,r.pdf'
+        clean = checker.filename_cleanup(file)
+        self.assertEqual(file, clean)
+
+        file = ''
+        clean = checker.filename_cleanup(file)
+        self.assertEqual(file, clean)
+
+        file = None
+        clean = checker.filename_cleanup(file)
+        self.assertEqual(file, clean)
+
+        file = '/foo/bar.pdf,/foo/baz.pdf'
+        clean = checker.filename_cleanup(file)
+        self.assertEqual('/foo/bar.pdf', clean)
+
+        file = '/foo/bar.pdf,/foo/baz.pdf,/foo/quux.pdf'
+        clean = checker.filename_cleanup(file)
+        self.assertEqual('/foo/bar.pdf', clean)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
the fulltext is spread over multiple files for over 11k bibcodes.  currently, fulltext fails on all of them.  with this change only the first file of the list of files will be processed.  this is very much a partial solution, fortunately the first file holds the bulk of the text.  other files in the list typically hold text from tables.