### PR TITLE
Support multiple input files for a bibcode

### DIFF
--- a/adsft/extraction.py
+++ b/adsft/extraction.py
@@ -904,7 +904,11 @@ def extract_content(input_list, **kwargs):
 
                     for item in parsed_content:
                         if item in dict_item:
-                            dict_item[item] += parsed_content[item]
+                            # values can be strings or, for dataset, a list
+                            if isinstance(dict_item[item], str):
+                                dict_item[item] += ' ' + parsed_content[item]
+                            else:
+                                dict_item[item] += parsed_content[item]
                         else:
                             dict_item[item] = parsed_content[item]
 

--- a/adsft/extraction.py
+++ b/adsft/extraction.py
@@ -24,7 +24,7 @@ import os
 import requests
 from adsputils import overrides
 from adsputils import setup_logging
-from adsft.utils import TextCleaner
+from adsft.utils import TextCleaner, get_filenames
 from adsft import reader
 import re
 import traceback
@@ -885,7 +885,6 @@ def extract_content(input_list, **kwargs):
                         and dict_item['provider'] == 'Elsevier':
 
                     extension = "elsevier"
-
                 ExtractorClass = EXTRACTOR_FACTORY[extension]
 
             except KeyError:
@@ -896,11 +895,19 @@ def extract_content(input_list, **kwargs):
             try:
                 dict_item['grobid_service'] = kwargs.get('grobid_service', None)
                 dict_item['extract_pdf_script'] = kwargs.get('extract_pdf_script', None)
-                extractor = ExtractorClass(dict_item)
-                parsed_content = extractor.extract_multi_content()
+                # get one or more files from ft_source and process
+                files = get_filenames(dict_item['ft_source'])
+                for f in files:
+                    dict_item['ft_source'] = f
+                    extractor = ExtractorClass(dict_item)
+                    parsed_content = extractor.extract_multi_content()
 
-                for item in parsed_content:
-                    dict_item[item] = parsed_content[item]
+                    for item in parsed_content:
+                        if item in dict_item:
+                            dict_item[item] += parsed_content[item]
+                        else:
+                            dict_item[item] = parsed_content[item]
+
                 del dict_item['grobid_service']
                 del dict_item['extract_pdf_script']
 

--- a/adsft/tests/test_base.py
+++ b/adsft/tests/test_base.py
@@ -176,6 +176,8 @@ class TestUnit(unittest.TestCase):
         self.test_stub_iso8859 = \
             os.path.join(PROJ_HOME,
                          'tests/test_unit/stub_data/test.stmp_2_1_014010.iop.xml')
+        self.test_multi_file = os.path.join(PROJ_HOME, 'tests/test_unit/stub_data/test.xml') + \
+            ',' + os.path.join(PROJ_HOME,'tests/test_unit/stub_data/test.xml')
         self.test_stub_html = \
             os.path.join(PROJ_HOME,
                          'tests/test_unit/stub_data/test.html')

--- a/adsft/tests/test_checker.py
+++ b/adsft/tests/test_checker.py
@@ -341,32 +341,6 @@ class TestCheckIfExtracted(test_base.TestUnit):
                         'DIFFERING_FULL_TEXT')
         self.assertTrue(len(payload_false['PDF']) != 0)
 
-    def test_filename_cleanup(self):
-        """check code that deals with multiple files for bibcode"""
-
-        file = '/foo/bar.pdf'
-        clean = checker.filename_cleanup(file)
-        self.assertEqual(file, clean)
-
-        file = '/foo/ba,r.pdf'
-        clean = checker.filename_cleanup(file)
-        self.assertEqual(file, clean)
-
-        file = ''
-        clean = checker.filename_cleanup(file)
-        self.assertEqual(file, clean)
-
-        file = None
-        clean = checker.filename_cleanup(file)
-        self.assertEqual(file, clean)
-
-        file = '/foo/bar.pdf,/foo/baz.pdf'
-        clean = checker.filename_cleanup(file)
-        self.assertEqual('/foo/bar.pdf', clean)
-
-        file = '/foo/bar.pdf,/foo/baz.pdf,/foo/quux.pdf'
-        clean = checker.filename_cleanup(file)
-        self.assertEqual('/foo/bar.pdf', clean)
 
 
 if __name__ == '__main__':

--- a/adsft/tests/test_extraction.py
+++ b/adsft/tests/test_extraction.py
@@ -74,6 +74,23 @@ class TestXMLExtractor(test_base.TestUnit):
 
         self.assertEqual(article_number, '483879')
 
+    def test_multi_file(self):
+        """
+        some entries in fulltext/all.links specify multiple files 
+
+        typically the first has text from the article while the rest have the text from tables
+
+        :return: no return
+        """
+        self.dict_item = {'ft_source': self.test_multi_file,
+                          'file_format': 'xml',
+                          'provider': 'MNRAS',
+                          'bibcode': 'test'}
+
+        content = extraction.extract_content([self.dict_item])
+        # does the fulltext contain two copies of the file's contents
+        self.assertEqual(2, content[0]['fulltext'].count('Entry 1'))
+
 
     def test_that_we_can_extract_using_settings_template(self):
         """

--- a/adsft/tests/test_util.py
+++ b/adsft/tests/test_util.py
@@ -66,5 +66,29 @@ class TestFileStreamInput(test_base.TestUnit):
             r = utils.TextCleaner(x).run(translate=False, decode=True, normalise=True, trim=True)
             self.assertEqual(r, u'a b')
 
+    def test_get_filenames(self):
+        """test code that breaks up file name strings"""
+
+        file_string = '/proj/ads/foo'
+        files = utils.get_filenames(file_string)
+        self.assertEqual([file_string], files)
+
+        file_string = '/proj/ads/foo,/proj/ads/bar'
+        files = utils.get_filenames(file_string)
+        self.assertEqual(['/proj/ads/foo', '/proj/ads/bar'], files)
+
+        file_string = '/proj/ads/foo,/proj/ads/,,/bar'
+        files = utils.get_filenames(file_string)
+        self.assertEqual(['/proj/ads/foo', '/proj/ads/,,/bar'], files)
+
+        file_string = '/proj/ads/foo,/proj/ads/ba,r'
+        files = utils.get_filenames(file_string)
+        self.assertEqual(['/proj/ads/foo', '/proj/ads/ba,r'], files)
+
+        file_string = '/proj/ads/foo,/proj/ads/ba,r,/proj/ads/baz/,,/qu,ux'
+        files = utils.get_filenames(file_string)
+        self.assertEqual(['/proj/ads/foo', '/proj/ads/ba,r', '/proj/ads/baz/,,/qu,ux'], files)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/adsft/utils.py
+++ b/adsft/utils.py
@@ -270,3 +270,31 @@ class TextCleaner(object):
             self.trimwords()
 
         return self.text
+
+def get_filenames(file_string):
+    """convert passed string containing one or more files to an array of files 
+
+    file_string could be a sigle file, a simple comma separated list of files
+    or it could include a comman in either the filename or the pathname
+    we can't use a comma as a delimeter
+    instead, since all paths are absolute, we use the first two directory names
+    in the absolution path as a delimter
+    example simple input:
+    /proj/ads/fulltext/sources/A+A/backdata/2003/17/aah3724/aah3724.right.html,/proj/ads/fulltext/sources/A+A/backdata/2003/17/aah3724/tableE.1.html
+    example input with comman in filename:
+    /proj/ads/fulltext/sources/downloads/cache/POS/pos.sissa.it//archive/conferences/075/001/BHs,%20GR%20and%20Strings_001.pdf
+    """
+    if file_string[0] != '/':
+        raise ValueError('expected absolute pathname to start with / character: {}'.format(file_string))
+    second_slash_index = file_string.index('/', 1)
+    third_slash_index = file_string.index('/', second_slash_index+1)
+    prefix = file_string[:third_slash_index+1]
+    
+    # split input string over prefix delimeter, add prefix back to string
+    files = [prefix+f for f in file_string.split(prefix) if f]
+    # remove trailing commas, they are actual delimiters
+    for i in range(0, len(files)):
+        if files[i][-1] == ',':
+            files[i] = files[i][:-1]
+
+    return files


### PR DESCRIPTION
https://github.com/adsabs/ADSfulltext/issues/65
Fulltext genereated an error when fulltext/all.links specified multiple files for a bibcode.  This fix reads data from all the specified files, concatenating the results.  Note that comma characters occur in pathnames and filenames, this complicates breaking a line from all.links into multiple file names.