### PR TITLE
modify rules.py dictionary to include bdy tags for Nature articles

### DIFF
--- a/adsft/rules.py
+++ b/adsft/rules.py
@@ -3,7 +3,8 @@ META_CONTENT = {
         'fulltext': {
             'xpath': ['//body',
                       '//section[@type="body"]',
-                      '//journalarticle-body'
+                      '//journalarticle-body',
+                      '//bdy'
                       ],
             'type': 'string',
             'info': '',


### PR DESCRIPTION
This is to fix issue #71, where the problem is that Nature uses bdy tags for its article body which was not listed as one of the tags we look for when parsing xml articles.  