### PR TITLE
add appendix to fulltext

### DIFF
--- a/adsft/extraction.py
+++ b/adsft/extraction.py
@@ -480,8 +480,10 @@ class StandardExtractorXML(object):
         else:
             translate = False
 
-        if self.parsed_xml.xpath(static_xpath):
-            text_content = self.parsed_xml.xpath(static_xpath)[0].text_content()
+        s = self.parsed_xml.xpath(static_xpath)
+
+        if s:
+            text_content = s[0].text_content()
         old = text_content
         text_content = TextCleaner(text=text_content).run(
             decode=decode,
@@ -594,7 +596,8 @@ class StandardExtractorXML(object):
                     )
 
                     if text_content:
-                        # ensure content is not repeated due to nested xpaths
+                        # this is to deal with situations where the appendix is found inside of the body tags
+                        # or when multiple xpaths return the same result which happens in some cases for the acknowledgments
                         for s in all_text_content:
                             if text_content in s:
                                 unique = False
@@ -630,12 +633,10 @@ class StandardExtractorXML(object):
                                  )
                     raise Exception(traceback.format_exc())
 
-                if META_CONTENT[self.meta_name][content_name]['type'] == 'string':
-                    meta_out[content_name] = "\n".join(all_text_content)
-                elif len(all_text_content) > 0:
-                    meta_out[content_name] = all_text_content[0]
-                else:
-                    meta_out[content_name] = all_text_content
+            if META_CONTENT[self.meta_name][content_name]['type'] == 'string':
+                meta_out[content_name] = "\n".join(all_text_content)
+            elif len(all_text_content) > 0:
+                meta_out[content_name] = all_text_content[0]
 
         return meta_out
 

--- a/adsft/rules.py
+++ b/adsft/rules.py
@@ -1,3 +1,6 @@
+'''The xpath order is very important here because we are appending all of the results
+for each xpath, rather than taking the first one that returns something other than null.
+If the order is changed specifically for app-group we will have to modify our unique test.'''
 META_CONTENT = {
     'xml': {
         'fulltext': {

--- a/adsft/rules.py
+++ b/adsft/rules.py
@@ -4,7 +4,8 @@ META_CONTENT = {
             'xpath': ['//body',
                       '//section[@type="body"]',
                       '//journalarticle-body',
-                      '//bdy'
+                      '//bdy',
+                      '//app-group'
                       ],
             'type': 'string',
             'info': '',
@@ -42,6 +43,7 @@ META_CONTENT = {
         'fulltext': {
             'xpath': ['//body',
                       '//raw-text',
+                      '//appendices',
                       ],
             'type': 'string',
             'info': '',

--- a/adsft/tests/test_full_range_of_formats.py
+++ b/adsft/tests/test_full_range_of_formats.py
@@ -133,7 +133,7 @@ class TestFullRangeFormatExtraction(test_base.TestGeneric):
                 expected_fulltext_content = (
                         u"Introduction\n\nTHIS IS AN INTERESTING TITLE\n",
                         u"Introduction\n\nTHIS IS AN INTERESTING TITLE\n",
-                        u"\nI.INTRODUCTION\nINTRODUCTION GOES HERE\n\n\nManual Entry\n\n",
+                        u"\nI.INTRODUCTION\nINTRODUCTION GOES HERE\n\n\nManual Entry\n\n\n\n\nAPPENDIX: APPENDIX TITLE GOES HERE\nAPPENDIX CONTENT\n\n",
                         '\n\napplication/xml\nJOURNAL TITLE\nCREATOR\n\n\nSUBJECT\n\nDESCRIPTION\nJOURNAL\nNAME\nCOPYRIGHT\nPUBLISHER\n9999-9999\nVOLUME\nDAY MONTH YEAR\n1999-99-99\n999-999\n999\n999\n99.9999/9.99999.9999.99.999\nhttp://dx.doi.org/99.9999/9.99999.9999.99.999\ndoi:99.9999/9.99999.9999.99.999\n\n\nJournals\nS300.1\n\n\n\nJOURNAL\n999999\n99999-9999(99)99999-9\n99.9999/9.99999.9999.99.999\nCOPYRIGHT\n\n\n\nFig.1\n\n\n CONTENT\n \n\n\n\n\n\nTITLE\n\n\nGIVEN NAME\nSURNAME\n\na\n\n\n#x204e;\n\nEMAIL@EMAIL.COM\n\na\nAFFILIATION\n#x204e;\nAUTHOR\n\n\n\n\n\n\nAbstract\nABSTRACT\n\n\n\nHighlights\n\nHIGHLIGHTS\n\n\nKeywords\n\nKEYWORD\n\n\n\n\n1\nIntroduction\nJOURNAL CONTENT\n\n\n\nAcknowledgments\nTHANK YOU\n\n\nAppendix A\nAPPENDIX TITLE\nAPPENDIX\n\n\n\n\n\nReferences\n\nAUTHOR et al., 1999\n\n\n\n\nGIVEN NAME\nSURNAME\n\n\n\nTITLE\n\n\n\n\n\n\nTITLE\n \n\nVOLUME\n\nYEAR\n\n\n99\n99\n\n\n\n\n\n\n\n\n\n',
 
                         u"No Title AA 999, 999-999 (1999)\n DOI: 99.9999/9999-9999:99999999\n\n TITLE AUTHOR AFFILIATION Received 99 MONTH 1999 / Accepted 99 MONTH 1999 Abstract ABSTRACT\n\n Key words: KEYWORD\n \n INTRODUCTION\n\n SECTION Table 1: TABLE TABLE (1) \n COPYRIGHT\n ",

--- a/adsft/tests/test_tasks.py
+++ b/adsft/tests/test_tasks.py
@@ -79,7 +79,7 @@ class TestWorkers(unittest.TestCase):
                 self.assertTrue(task_write_text.called)
                 actual = task_write_text.call_args[0][0]
 
-                self.assertEqual(u'\nI.INTRODUCTION\nINTRODUCTION GOES HERE\n\n\nManual Entry\n\n', actual['fulltext'])
+                self.assertEqual(u'\nI.INTRODUCTION\nINTRODUCTION GOES HERE\n\n\nManual Entry\n\n\n\n\nAPPENDIX: APPENDIX TITLE GOES HERE\nAPPENDIX CONTENT\n\n', actual['fulltext'])
                 self.assertEqual(u'\nAcknowledgments\nWE ACKNOWLEDGE.', actual['acknowledgements'])
                 self.assertEqual([u'ADS/Sa.CXO#Obs/11458'], actual['dataset'])
                 self.assertTrue(task_output_results.called)


### PR DESCRIPTION
This fixes issue #73 and #23 by adding the appendix to the fulltext when it is located outside of the body of the article.