### PR TITLE
separate acknowledgement from body, remove bibliography

### DIFF
--- a/adsft/extraction.py
+++ b/adsft/extraction.py
@@ -480,6 +480,16 @@ class StandardExtractorXML(object):
             # - A processing instruction is coded like this: <?ignore .... what ever I want here, including <!-- comments --> ...  ?>
             #   RegEx Source: https://stackoverflow.com/a/29418829/6940788
             raw_xml = re.sub('<\?[^>]+\?>', '', raw_xml) # Processing instructions
+        if parser_name in ("html5lib",):
+            # - Convert self closing xml tags to closing tags
+            #   Source: https://stackoverflow.com/a/14028108
+            # - html5lib will close them itself (unless it is a recognised html
+            #   tag) at a later point in the document, wrapping other content,
+            #   and if it turns out to be a tag that we want to remove
+            #   (i.e., graphics), we will wrongly remove the content that was
+            #   wrapped
+            raw_xml = re.sub('<\s*([^\s>]+)([^>]*)/\s*>', r'<\1\2></\1>', raw_xml) # Self closing tags (e.g., <graphics/>) to closing tabs (e.g., <graphics></graphics>)
+
         return raw_xml
 
     def _save_body_tag(self, raw_xml):

--- a/adsft/extraction.py
+++ b/adsft/extraction.py
@@ -453,7 +453,7 @@ class StandardExtractorXML(object):
         """
         parent = node.getparent()
 
-        if parent.text is not None:
+        if parent != None:
             parent.remove(node)
             parent.addnext(node)
 

--- a/adsft/extraction.py
+++ b/adsft/extraction.py
@@ -574,7 +574,7 @@ class StandardExtractorXML(object):
                 elem.tag = elem.tag[i+1:]
         return parsed_xml
 
-    def parse_xml(self, preferred_parser_names = ["lxml-xml", "html.parser", "lxml-html", "direct-lxml-html", "direct-lxml-xml", "html5lib"]):
+    def parse_xml(self, preferred_parser_names = ("lxml-xml", "html.parser", "lxml-html", "direct-lxml-html", "direct-lxml-xml", "html5lib",)):
         """
         Parses the encoded string read from the opened XML file.
         Tries multiple parsers (sorted by order of preference), it stops trying
@@ -792,7 +792,7 @@ class StandardExtractorXML(object):
 
         return data_inner
 
-    def extract_multi_content(self, translate=False, decode=False, preferred_parser_names=["lxml-xml", "html.parser", "lxml-html", "direct-lxml-html", "direct-lxml-xml", "html5lib"]):
+    def extract_multi_content(self, translate=False, decode=False, preferred_parser_names=("lxml-xml", "html.parser", "lxml-html", "direct-lxml-html", "direct-lxml-xml", "html5lib",)):
         """
         Extracts full text content from the XML article specified. It also
         extracts any content specified in settings.py. It expects that the user

--- a/adsft/extraction.py
+++ b/adsft/extraction.py
@@ -682,14 +682,6 @@ class StandardExtractorXML(object):
             # and restore the original body tag
             parsed_xml = self._restore_body_tag(parsed_xml, random_body_tag)
 
-        # remove tables, formulas, figures and bibliography
-        for e in parsed_xml.xpath("//table | //graphic | //disp-formula | ////inline-formula | //formula | //tex-math | //processing-instruction('CDATA') | //bibliography"):
-            self._remove_keeping_tail(e)
-
-        # move acknowledgments after body (most likely only a minority of documents have this problem)
-        for e in parsed_xml.xpath(" | ".join(META_CONTENT['xml']['acknowledgements']['xpath'])):
-            self._append_tag_outside_parent(e)
-
         if parser_name in ("lxml-xml", "direct-lxml-xml") and parsed_xml.nsmap:
             # These parsers detect namespaces and expand the namespace prefixes
             # into their namespace, we need to remove them to make xpath work
@@ -702,6 +694,15 @@ class StandardExtractorXML(object):
             # (e.g., 'xlink:href'), we need to remove them to make xpath work
             # without having to specify the namespace prefixes
             parsed_xml = self._remove_namespace_prefixes(parsed_xml)
+
+        # remove tables, formulas, figures and bibliography
+        for e in parsed_xml.xpath("//table | //graphic | //disp-formula | ////inline-formula | //formula | //tex-math | //processing-instruction('CDATA') | //bibliography"):
+            self._remove_keeping_tail(e)
+
+        # move acknowledgments after body (most likely only a minority of documents have this problem)
+        for e in parsed_xml.xpath(" | ".join(META_CONTENT['xml']['acknowledgements']['xpath'])):
+            self._append_tag_outside_parent(e)
+
 
         return parsed_xml
 

--- a/adsft/tests/test_extraction.py
+++ b/adsft/tests/test_extraction.py
@@ -270,6 +270,43 @@ class TestXMLExtractor(test_base.TestUnit):
 
         self.assertEqual(section, u'TABLE I. TEXT a NOTES a TEXT')
 
+    def test_that_we_handle_extractors_that_remove_body_tag(self):
+
+        self.maxDiff = None
+        """
+        parsers: direct-lxml-html, lxml-html, html5lib
+
+        This tests that the above parsers are handled correctly
+        to ensure that the body tag is kept in place, as these parsers
+        will remove body tags if they are not in the format:
+
+        <html>
+        <head></head>
+        <body></body>
+        </html>
+
+         """
+
+        full_text_content = self.extractor.open_xml()
+
+        for parser_name in ["html5lib", "lxml-html", "direct-lxml-html"]:
+            self.extractor.parse_xml(preferred_parser_names=(parser_name,))
+
+            section = self.extractor.extract_string('//body')
+
+            if parser_name == "html5lib":
+                s = u"Manual Entry 1 Manual Entry 2 TABLE I. TEXT a"
+            else:
+                s = u"Manual Entry 1 Manual Entry 2 TABLE I. TEXT a NOTES a TEXT"
+
+            self.assertEqual(section, u"I. INTRODUCTION INTRODUCTION GOES HERE "
+                u"II. SECTION II THIS SECTION TESTS HTML ENTITIES LIKE \xc5 >. "
+                u"III. SECTION III THIS SECTION TESTS THAT THE TAIL IS PRESERVED . "
+                u"IV. SECTION IV THIS SECTION TESTS THAT COMMENTS ARE REMOVED. "
+                u"V. SECTION V THIS SECTION TESTS THAT CDATA IS REMOVED. " + s
+            )
+
+
 
 class TestTEIXMLExtractor(test_base.TestUnit):
     """

--- a/adsft/tests/test_extraction.py
+++ b/adsft/tests/test_extraction.py
@@ -270,9 +270,8 @@ class TestXMLExtractor(test_base.TestUnit):
 
         self.assertEqual(section, u'TABLE I. TEXT a NOTES a TEXT')
 
-    def test_that_we_handle_extractors_that_remove_body_tag(self):
+    def test_handling_of_parsers_that_remove_body_tag(self):
 
-        self.maxDiff = None
         """
         parsers: direct-lxml-html, lxml-html, html5lib
 

--- a/adsft/tests/test_extraction.py
+++ b/adsft/tests/test_extraction.py
@@ -27,6 +27,7 @@ class TestXMLExtractor(test_base.TestUnit):
                           'file_format': 'xml',
                           'provider': 'MNRAS'}
         self.extractor = extraction.EXTRACTOR_FACTORY['xml'](self.dict_item)
+        self.parsers = ("lxml-xml", "html.parser", "lxml-html", "direct-lxml-html", "direct-lxml-xml", "html5lib",)
 
     def test_that_we_can_open_an_xml_file(self):
         """
@@ -52,10 +53,16 @@ class TestXMLExtractor(test_base.TestUnit):
         """
 
         full_text_content = self.extractor.open_xml()
-        self.extractor.parse_xml()
-        journal_title = self.extractor.extract_string('//journal-title')
 
-        self.assertEqual(journal_title, 'JOURNAL TITLE')
+        if self.parsers:
+            for parser_name in self.parsers:
+                self.extractor.parse_xml(preferred_parser_names=(parser_name,))
+                journal_title = self.extractor.extract_string('//journal-title')
+                self.assertEqual(journal_title, 'JOURNAL TITLE')
+        else:
+            self.extractor.parse_xml()
+            journal_title = self.extractor.extract_string('//journal-title')
+            self.assertEqual(journal_title, 'JOURNAL TITLE')
 
     def test_that_we_correctly_remove_inline_fomulas_from_the_xml_content(self):
         """
@@ -67,10 +74,16 @@ class TestXMLExtractor(test_base.TestUnit):
         """
 
         full_text_content = self.extractor.open_xml()
-        self.extractor.parse_xml()
-        section = self.extractor.extract_string('//body//sec[@id="s1"]//p')
 
-        self.assertEqual(section, 'INTRODUCTION GOES HERE')
+        if self.parsers:
+            for parser_name in self.parsers:
+                self.extractor.parse_xml(preferred_parser_names=(parser_name,))
+                section = self.extractor.extract_string('//body//sec[@id="s1"]//p')
+                self.assertEqual(section, 'INTRODUCTION GOES HERE')
+        else:
+            self.extractor.parse_xml()
+            section = self.extractor.extract_string('//body//sec[@id="s1"]//p')
+            self.assertEqual(section, 'INTRODUCTION GOES HERE')
 
 
     def test_iso_8859_1_xml(self):
@@ -84,10 +97,16 @@ class TestXMLExtractor(test_base.TestUnit):
         self.dict_item['ft_source'] = self.test_stub_iso8859
         self.extractor = extraction.EXTRACTOR_FACTORY['xml'](self.dict_item)
         full_text_content = self.extractor.open_xml()
-        self.extractor.parse_xml()
-        article_number = self.extractor.extract_string('//article-number')
 
-        self.assertEqual(article_number, '483879')
+        if self.parsers:
+            for parser_name in self.parsers:
+                self.extractor.parse_xml(preferred_parser_names=(parser_name,))
+                article_number = self.extractor.extract_string('//article-number')
+                self.assertEqual(article_number, '483879')
+        else:
+            self.extractor.parse_xml()
+            article_number = self.extractor.extract_string('//article-number')
+            self.assertEqual(article_number, '483879')
 
     def test_multi_file(self):
         """
@@ -117,9 +136,13 @@ class TestXMLExtractor(test_base.TestUnit):
         """
 
         full_text_content = self.extractor.open_xml()
-        content = self.extractor.extract_multi_content()
-
-        self.assertEqual(rules.META_CONTENT['xml'].keys(), content.keys())
+        if self.parsers:
+            for parser_name in self.parsers:
+                content = self.extractor.extract_multi_content(preferred_parser_names=(parser_name,))
+                self.assertEqual(rules.META_CONTENT['xml'].keys(), content.keys())
+        else:
+            content = self.extractor.extract_multi_content(preferred_parser_names=(parser_name,))
+            self.assertEqual(rules.META_CONTENT['xml'].keys(), content.keys())
 
     def test_that_we_can_extract_all_content_from_payload_input(self):
         """
@@ -169,34 +192,66 @@ class TestXMLExtractor(test_base.TestUnit):
 
         self.dict_item['bibcode'] = 'test'
         full_text_content = self.extractor.open_xml()
-        content = self.extractor.extract_multi_content()
 
-        full_text = content['fulltext']
-        acknowledgements = content['acknowledgements']
-        data_set = content['dataset']
-        data_set_length = len(data_set)
+        if self.parsers:
+            for parser_name in self.parsers:
+                content = self.extractor.extract_multi_content(preferred_parser_names=(parser_name,))
 
-        self.assertIs(unicode, type(acknowledgements))
+                full_text = content['fulltext']
+                acknowledgements = content['acknowledgements']
+                data_set = content['dataset']
+                data_set_length = len(data_set)
 
-        self.assertIs(unicode, type(full_text))
-        expected_full_text = 'INTRODUCTION'
-        self.assertTrue(
-            expected_full_text in full_text,
-            u'Full text is wrong: {0} [expected: {1}, data: {2}]'
-            .format(full_text,
-                    expected_full_text,
-                    full_text)
-        )
+                self.assertIs(unicode, type(acknowledgements))
 
-        self.assertIs(list, type(data_set))
-        expected_dataset = 2
-        self.assertTrue(
-            data_set_length == expected_dataset,
-            u'Number of datasets is wrong: {0} [expected: {1}, data: {2}]'
-            .format(data_set_length,
-                    expected_dataset,
-                    data_set)
-        )
+                self.assertIs(unicode, type(full_text))
+                expected_full_text = 'INTRODUCTION'
+                self.assertTrue(
+                    expected_full_text in full_text,
+                    u'Full text is wrong: {0} [expected: {1}, data: {2}]'
+                    .format(full_text,
+                            expected_full_text,
+                            full_text)
+                )
+
+                self.assertIs(list, type(data_set))
+                expected_dataset = 2
+                self.assertTrue(
+                    data_set_length == expected_dataset,
+                    u'Number of datasets is wrong: {0} [expected: {1}, data: {2}]'
+                    .format(data_set_length,
+                            expected_dataset,
+                            data_set)
+                )
+        else:
+            content = self.extractor.extract_multi_content()
+
+            full_text = content['fulltext']
+            acknowledgements = content['acknowledgements']
+            data_set = content['dataset']
+            data_set_length = len(data_set)
+
+            self.assertIs(unicode, type(acknowledgements))
+
+            self.assertIs(unicode, type(full_text))
+            expected_full_text = 'INTRODUCTION'
+            self.assertTrue(
+                expected_full_text in full_text,
+                u'Full text is wrong: {0} [expected: {1}, data: {2}]'
+                .format(full_text,
+                        expected_full_text,
+                        full_text)
+            )
+
+            self.assertIs(list, type(data_set))
+            expected_dataset = 2
+            self.assertTrue(
+                data_set_length == expected_dataset,
+                u'Number of datasets is wrong: {0} [expected: {1}, data: {2}]'
+                .format(data_set_length,
+                        expected_dataset,
+                        data_set)
+            )
 
     def test_that_we_can_parse_html_entity_correctly(self):
         """
@@ -207,10 +262,15 @@ class TestXMLExtractor(test_base.TestUnit):
         """
 
         full_text_content = self.extractor.open_xml()
-        self.extractor.parse_xml()
-        section = self.extractor.extract_string('//body//sec[@id="s2"]//p')
-
-        self.assertEqual(section, u'THIS SECTION TESTS HTML ENTITIES LIKE \xc5 >.')
+        if self.parsers:
+            for parser_name in self.parsers:
+                self.extractor.parse_xml(preferred_parser_names=(parser_name,))
+                section = self.extractor.extract_string('//body//sec[@id="s2"]//p')
+                self.assertEqual(section, u'THIS SECTION TESTS HTML ENTITIES LIKE \xc5 >.')
+        else:
+            self.extractor.parse_xml()
+            section = self.extractor.extract_string('//body//sec[@id="s2"]//p')
+            self.assertEqual(section, u'THIS SECTION TESTS HTML ENTITIES LIKE \xc5 >.')
 
     def test_that_the_tail_is_preserved(self):
         """
@@ -221,10 +281,15 @@ class TestXMLExtractor(test_base.TestUnit):
         """
 
         full_text_content = self.extractor.open_xml()
-        self.extractor.parse_xml()
-        section = self.extractor.extract_string('//body//sec[@id="s3"]//p')
-
-        self.assertEqual(section, u'THIS SECTION TESTS THAT THE TAIL IS PRESERVED .')
+        if self.parsers:
+            for parser_name in self.parsers:
+                self.extractor.parse_xml(preferred_parser_names=(parser_name,))
+                section = self.extractor.extract_string('//body//sec[@id="s3"]//p')
+                self.assertEqual(section, u'THIS SECTION TESTS THAT THE TAIL IS PRESERVED .')
+        else:
+            self.extractor.parse_xml()
+            section = self.extractor.extract_string('//body//sec[@id="s3"]//p')
+            self.assertEqual(section, u'THIS SECTION TESTS THAT THE TAIL IS PRESERVED .')
 
     def test_that_comments_are_ignored(self):
         """
@@ -234,10 +299,15 @@ class TestXMLExtractor(test_base.TestUnit):
         """
 
         full_text_content = self.extractor.open_xml()
-        self.extractor.parse_xml()
-        section = self.extractor.extract_string('//body//sec[@id="s4"]//p')
-
-        self.assertEqual(section, u'THIS SECTION TESTS THAT COMMENTS ARE REMOVED.')
+        if self.parsers:
+            for parser_name in self.parsers:
+                self.extractor.parse_xml(preferred_parser_names=(parser_name,))
+                section = self.extractor.extract_string('//body//sec[@id="s4"]//p')
+                self.assertEqual(section, u'THIS SECTION TESTS THAT COMMENTS ARE REMOVED.')
+        else:
+            self.extractor.parse_xml()
+            section = self.extractor.extract_string('//body//sec[@id="s4"]//p')
+            self.assertEqual(section, u'THIS SECTION TESTS THAT COMMENTS ARE REMOVED.')
 
     def test_that_cdata_is_removed(self):
         """
@@ -250,25 +320,47 @@ class TestXMLExtractor(test_base.TestUnit):
         """
 
         full_text_content = self.extractor.open_xml()
-        self.extractor.parse_xml()
-        section = self.extractor.extract_string('//body//sec[@id="s5"]//p')
-
-        self.assertEqual(section, u'THIS SECTION TESTS THAT CDATA IS REMOVED.')
+        if self.parsers:
+            for parser_name in self.parsers:
+                self.extractor.parse_xml(preferred_parser_names=(parser_name,))
+                section = self.extractor.extract_string('//body//sec[@id="s5"]//p')
+                self.assertEqual(section, u'THIS SECTION TESTS THAT CDATA IS REMOVED.')
+        else:
+            self.extractor.parse_xml()
+            section = self.extractor.extract_string('//body//sec[@id="s5"]//p')
+            self.assertEqual(section, u'THIS SECTION TESTS THAT CDATA IS REMOVED.')
 
     def test_that_table_is_extracted_correctly(self):
         """
         Tests that the labels/comments for tables are kept while the content of
-        the table is removed. Tables outside of the body field are currently being
-        ignored.
+        the table is removed. Table footers are being removed in some cases where
+        a graphic tag with no closing tag like <graphic xlink:href="example.gif">
+        is reconciled with a closing tag that encompasses additonal content like the
+        table footer. Since graphics are one of the tags we remove to avoid garbage
+        text in our output, it correctly gets removed but takes content that should remain
+        in the fulltext output with it (like the table footer).
 
         :return: no return
         """
 
         full_text_content = self.extractor.open_xml()
-        self.extractor.parse_xml()
-        section = self.extractor.extract_string('//body//table-wrap')
 
-        self.assertEqual(section, u'TABLE I. TEXT a NOTES a TEXT')
+        if self.parsers:
+            for parser_name in self.parsers:
+
+                # we know that html5lib does not extract tables correctly in all cases
+                if parser_name == "html5lib":
+                    s = u"TABLE I. TEXT a"
+                else:
+                    s = u"TABLE I. TEXT a NOTES a TEXT"
+
+                self.extractor.parse_xml(preferred_parser_names=(parser_name,))
+                section = self.extractor.extract_string('//body//table-wrap')
+                self.assertEqual(section, s)
+        else:
+            self.extractor.parse_xml()
+            section = self.extractor.extract_string('//body//table-wrap')
+            self.assertEqual(section, s)
 
     def test_handling_of_parsers_that_remove_body_tag(self):
 
@@ -288,9 +380,8 @@ class TestXMLExtractor(test_base.TestUnit):
 
         full_text_content = self.extractor.open_xml()
 
-        for parser_name in ["html5lib", "lxml-html", "direct-lxml-html"]:
+        for parser_name in ("html5lib", "lxml-html", "direct-lxml-html",):
             self.extractor.parse_xml(preferred_parser_names=(parser_name,))
-
             section = self.extractor.extract_string('//body')
 
             if parser_name == "html5lib":
@@ -308,6 +399,8 @@ class TestXMLExtractor(test_base.TestUnit):
     def test_handling_of_parsers_that_detect_namespaces(self):
 
         """
+        parsers: lxml-xml, direct-lxml-xml
+
         Tests that namespace in tags of the form namespace:name (e.g. ja:body)
         are removed to get the tag name as a result (e.g. body)
 
@@ -316,10 +409,9 @@ class TestXMLExtractor(test_base.TestUnit):
 
         full_text_content = self.extractor.open_xml()
 
-        for parser_name in ["lxml-xml", "direct-lxml-xml"]:
+        for parser_name in ("lxml-xml", "direct-lxml-xml",):
 
             self.extractor.parse_xml(preferred_parser_names=(parser_name,))
-
             section = self.extractor.extract_string('//body')
 
             self.assertEqual(section, u"I. INTRODUCTION INTRODUCTION GOES HERE "
@@ -446,6 +538,7 @@ class TestXMLElsevierExtractor(test_base.TestUnit):
                           'bibcode': 'TEST'
                           }
         self.extractor = extraction.EXTRACTOR_FACTORY['elsevier'](self.dict_item)
+        self.parsers = ("lxml-xml", "html.parser", "lxml-html", "direct-lxml-html", "direct-lxml-xml", "html5lib",)
 
 
     def test_that_we_can_open_an_xml_file(self):
@@ -470,9 +563,16 @@ class TestXMLElsevierExtractor(test_base.TestUnit):
         """
 
         full_text_content = self.extractor.open_xml()
-        self.extractor.parse_xml()
-        journal_title = self.extractor.extract_string('//*[local-name()=\'title\']')
-        self.assertIn('JOURNAL TITLE', journal_title)
+
+        if self.parsers:
+            for parser_name in self.parsers:
+                self.extractor.parse_xml(preferred_parser_names=(parser_name,))
+                journal_title = self.extractor.extract_string('//*[local-name()=\'title\']')
+                self.assertIn('JOURNAL TITLE', journal_title)
+        else:
+            self.extractor.parse_xml()
+            journal_title = self.extractor.extract_string('//*[local-name()=\'title\']')
+            self.assertIn('JOURNAL TITLE', journal_title)
 
     def test_that_we_can_extract_using_settings_template(self):
         """
@@ -484,13 +584,23 @@ class TestXMLElsevierExtractor(test_base.TestUnit):
         """
 
         full_text_content = self.extractor.open_xml()
-        content = self.extractor.extract_multi_content()
+        if self.parsers:
+            for parser_name in self.parsers:
+                content = self.extractor.extract_multi_content(preferred_parser_names=(parser_name,))
 
-        self.assertItemsEqual(['fulltext', 'acknowledgements', 'dataset'],
-                              content.keys(),
-                              content.keys())
+                self.assertItemsEqual(['fulltext', 'acknowledgements', 'dataset'],
+                                      content.keys(),
+                                      content.keys())
 
-        self.assertIn('JOURNAL CONTENT', content['fulltext'])
+                self.assertIn('JOURNAL CONTENT', content['fulltext'])
+        else:
+                content = self.extractor.extract_multi_content()
+
+                self.assertItemsEqual(['fulltext', 'acknowledgements', 'dataset'],
+                                      content.keys(),
+                                      content.keys())
+
+                self.assertIn('JOURNAL CONTENT', content['fulltext'])
 
     def test_that_the_correct_extraction_is_used_for_the_datatype(self):
         """
@@ -522,34 +632,66 @@ class TestXMLElsevierExtractor(test_base.TestUnit):
 
         self.dict_item['bibcode'] = 'test'
         full_text_content = self.extractor.open_xml()
-        content = self.extractor.extract_multi_content()
 
-        full_text = content['fulltext']
-        acknowledgements = content['acknowledgements']
-        data_set = content['dataset']
-        data_set_length = len(data_set)
+        if self.parsers:
+            for parser_name in self.parsers:
+                content = self.extractor.extract_multi_content(preferred_parser_names=(parser_name,))
 
-        self.assertIs(unicode, type(acknowledgements))
+                full_text = content['fulltext']
+                acknowledgements = content['acknowledgements']
+                data_set = content['dataset']
+                data_set_length = len(data_set)
 
-        self.assertIs(unicode, type(full_text))
-        expected_full_text = 'CONTENT'
-        self.assertTrue(
-            expected_full_text in full_text,
-            u'Full text is wrong: {0} [expected: {1}, data: {2}]'
-            .format(full_text,
-                    expected_full_text,
-                    full_text)
-        )
+                self.assertIs(unicode, type(acknowledgements))
 
-        self.assertIs(list, type(data_set))
-        expected_dataset = 2
-        self.assertTrue(
-            data_set_length == expected_dataset,
-            u'Number of datasets is wrong: {0} [expected: {1}, data: {2}]'
-            .format(data_set_length,
-                    expected_dataset,
-                    data_set)
-        )
+                self.assertIs(unicode, type(full_text))
+                expected_full_text = 'CONTENT'
+                self.assertTrue(
+                    expected_full_text in full_text,
+                    u'Full text is wrong: {0} [expected: {1}, data: {2}]'
+                    .format(full_text,
+                            expected_full_text,
+                            full_text)
+                )
+
+                self.assertIs(list, type(data_set))
+                expected_dataset = 2
+                self.assertTrue(
+                    data_set_length == expected_dataset,
+                    u'Number of datasets is wrong: {0} [expected: {1}, data: {2}]'
+                    .format(data_set_length,
+                            expected_dataset,
+                            data_set)
+                )
+        else:
+            content = self.extractor.extract_multi_content()
+
+            full_text = content['fulltext']
+            acknowledgements = content['acknowledgements']
+            data_set = content['dataset']
+            data_set_length = len(data_set)
+
+            self.assertIs(unicode, type(acknowledgements))
+
+            self.assertIs(unicode, type(full_text))
+            expected_full_text = 'CONTENT'
+            self.assertTrue(
+                expected_full_text in full_text,
+                u'Full text is wrong: {0} [expected: {1}, data: {2}]'
+                .format(full_text,
+                        expected_full_text,
+                        full_text)
+            )
+
+            self.assertIs(list, type(data_set))
+            expected_dataset = 2
+            self.assertTrue(
+                data_set_length == expected_dataset,
+                u'Number of datasets is wrong: {0} [expected: {1}, data: {2}]'
+                .format(data_set_length,
+                        expected_dataset,
+                        data_set)
+            )
 
     def test_that_we_can_parse_html_entity_correctly(self):
         """
@@ -560,24 +702,39 @@ class TestXMLElsevierExtractor(test_base.TestUnit):
         """
 
         full_text_content = self.extractor.open_xml()
-        self.extractor.parse_xml()
-        section = self.extractor.extract_string('//body//section[@id="s2"]//para')
 
-        self.assertEqual(section, u'THIS SECTION TESTS HTML ENTITIES LIKE \xc5 >.')
+        if self.parsers:
+            for parser_name in self.parsers:
+                self.extractor.parse_xml(preferred_parser_names=(parser_name,))
+                section = self.extractor.extract_string('//body//section[@id="s2"]//para')
+                self.assertEqual(section, u'THIS SECTION TESTS HTML ENTITIES LIKE \xc5 >.')
+        else:
+            self.extractor.parse_xml()
+            section = self.extractor.extract_string('//body//section[@id="s2"]//para')
+            self.assertEqual(section, u'THIS SECTION TESTS HTML ENTITIES LIKE \xc5 >.')
 
     def test_that_the_tail_is_preserved(self):
         """
         Tests that when a tag is removed any trailing text is preserved by appending
         it to the previous or parent element.
 
+        This test currently only works with the lxml-xml parser when extracting
+        Elsevier XML data.
+
         :return: no return
         """
 
         full_text_content = self.extractor.open_xml()
-        self.extractor.parse_xml()
-        section = self.extractor.extract_string('//body//section[@id="s3"]//para')
 
-        self.assertEqual(section, u'THIS SECTION TESTS THAT THE TAIL IS PRESERVED .')
+        if self.parsers:
+            for parser_name in ("lxml-xml",): # this is the only parser that works for this unit test
+                self.extractor.parse_xml(preferred_parser_names=(parser_name,))
+                section = self.extractor.extract_string('//body//section[@id="s3"]//para')
+                self.assertEqual(section, u'THIS SECTION TESTS THAT THE TAIL IS PRESERVED .')
+        else:
+            self.extractor.parse_xml()
+            section = self.extractor.extract_string('//body//section[@id="s3"]//para')
+            self.assertEqual(section, u'THIS SECTION TESTS THAT THE TAIL IS PRESERVED .')
 
     def test_that_comments_are_ignored(self):
         """
@@ -587,10 +744,16 @@ class TestXMLElsevierExtractor(test_base.TestUnit):
         """
 
         full_text_content = self.extractor.open_xml()
-        self.extractor.parse_xml()
-        section = self.extractor.extract_string('//body//section[@id="s4"]//para')
 
-        self.assertEqual(section, u'THIS SECTION TESTS THAT COMMENTS ARE REMOVED.')
+        if self.parsers:
+            for parser_name in self.parsers:
+                self.extractor.parse_xml(preferred_parser_names=(parser_name,))
+                section = self.extractor.extract_string('//body//section[@id="s4"]//para')
+                self.assertEqual(section, u'THIS SECTION TESTS THAT COMMENTS ARE REMOVED.')
+        else:
+            self.extractor.parse_xml()
+            section = self.extractor.extract_string('//body//section[@id="s4"]//para')
+            self.assertEqual(section, u'THIS SECTION TESTS THAT COMMENTS ARE REMOVED.')
 
 
 

--- a/adsft/tests/test_extraction.py
+++ b/adsft/tests/test_extraction.py
@@ -307,6 +307,13 @@ class TestXMLExtractor(test_base.TestUnit):
 
     def test_handling_of_parsers_that_detect_namespaces(self):
 
+        """
+        Tests that namespace in tags of the form namespace:name (e.g. ja:body)
+        are removed to get the tag name as a result (e.g. body)
+
+        :return: no return
+        """
+
         full_text_content = self.extractor.open_xml()
 
         for parser_name in ["lxml-xml", "direct-lxml-xml"]:
@@ -938,7 +945,6 @@ class TestHTTPExtractor(test_base.TestUnit):
         content = self.extractor.extract_multi_content()
 
         self.assertEqual(content['fulltext'], self.body_content)
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/adsft/tests/test_extraction.py
+++ b/adsft/tests/test_extraction.py
@@ -52,11 +52,10 @@ class TestXMLExtractor(test_base.TestUnit):
         """
 
         full_text_content = self.extractor.open_xml()
-        for parser_name in ("html5lib", "html.parser", "lxml-html", "direct-lxml-html", "lxml-xml", "direct-lxml-xml",):
-            self.extractor.parse_xml(preferred_parser_names=(parser_name,))
-            journal_title = self.extractor.extract_string('//journal-title')
+        self.extractor.parse_xml()
+        journal_title = self.extractor.extract_string('//journal-title')
 
-            self.assertEqual(journal_title, 'JOURNAL TITLE')
+        self.assertEqual(journal_title, 'JOURNAL TITLE')
 
     def test_that_we_correctly_remove_inline_fomulas_from_the_xml_content(self):
         """
@@ -68,11 +67,10 @@ class TestXMLExtractor(test_base.TestUnit):
         """
 
         full_text_content = self.extractor.open_xml()
-        for parser_name in ("html5lib", "html.parser", "lxml-html", "direct-lxml-html", "lxml-xml", "direct-lxml-xml",):
-            self.extractor.parse_xml(preferred_parser_names=(parser_name,))
-            section = self.extractor.extract_string('//body//sec[@id="s1"]//p')
+        self.extractor.parse_xml()
+        section = self.extractor.extract_string('//body//sec[@id="s1"]//p')
 
-            self.assertEqual(section, 'INTRODUCTION GOES HERE')
+        self.assertEqual(section, 'INTRODUCTION GOES HERE')
 
 
     def test_iso_8859_1_xml(self):
@@ -86,11 +84,10 @@ class TestXMLExtractor(test_base.TestUnit):
         self.dict_item['ft_source'] = self.test_stub_iso8859
         self.extractor = extraction.EXTRACTOR_FACTORY['xml'](self.dict_item)
         full_text_content = self.extractor.open_xml()
-        for parser_name in ("html5lib", "html.parser", "lxml-html", "direct-lxml-html", "lxml-xml", "direct-lxml-xml",):
-            self.extractor.parse_xml(preferred_parser_names=(parser_name,))
-            article_number = self.extractor.extract_string('//article-number')
+        self.extractor.parse_xml()
+        article_number = self.extractor.extract_string('//article-number')
 
-            self.assertEqual(article_number, '483879')
+        self.assertEqual(article_number, '483879')
 
     def test_multi_file(self):
         """
@@ -120,10 +117,9 @@ class TestXMLExtractor(test_base.TestUnit):
         """
 
         full_text_content = self.extractor.open_xml()
-        for parser_name in ("html5lib", "html.parser", "lxml-html", "direct-lxml-html", "lxml-xml", "direct-lxml-xml",):
-            content = self.extractor.extract_multi_content(preferred_parser_names=(parser_name,))
+        content = self.extractor.extract_multi_content()
 
-            self.assertEqual(rules.META_CONTENT['xml'].keys(), content.keys())
+        self.assertEqual(rules.META_CONTENT['xml'].keys(), content.keys())
 
     def test_that_we_can_extract_all_content_from_payload_input(self):
         """
@@ -173,35 +169,34 @@ class TestXMLExtractor(test_base.TestUnit):
 
         self.dict_item['bibcode'] = 'test'
         full_text_content = self.extractor.open_xml()
-        for parser_name in ("html5lib", "html.parser", "lxml-html", "direct-lxml-html", "lxml-xml", "direct-lxml-xml",):
-            content = self.extractor.extract_multi_content(preferred_parser_names=(parser_name,))
+        content = self.extractor.extract_multi_content()
 
-            full_text = content['fulltext']
-            acknowledgements = content['acknowledgements']
-            data_set = content['dataset']
-            data_set_length = len(data_set)
+        full_text = content['fulltext']
+        acknowledgements = content['acknowledgements']
+        data_set = content['dataset']
+        data_set_length = len(data_set)
 
-            self.assertIs(unicode, type(acknowledgements))
+        self.assertIs(unicode, type(acknowledgements))
 
-            self.assertIs(unicode, type(full_text))
-            expected_full_text = 'INTRODUCTION'
-            self.assertTrue(
-                expected_full_text in full_text,
-                u'Full text is wrong: {0} [expected: {1}, data: {2}]'
-                .format(full_text,
-                        expected_full_text,
-                        full_text)
-            )
+        self.assertIs(unicode, type(full_text))
+        expected_full_text = 'INTRODUCTION'
+        self.assertTrue(
+            expected_full_text in full_text,
+            u'Full text is wrong: {0} [expected: {1}, data: {2}]'
+            .format(full_text,
+                    expected_full_text,
+                    full_text)
+        )
 
-            self.assertIs(list, type(data_set))
-            expected_dataset = 2
-            self.assertTrue(
-                data_set_length == expected_dataset,
-                u'Number of datasets is wrong: {0} [expected: {1}, data: {2}]'
-                .format(data_set_length,
-                        expected_dataset,
-                        data_set)
-            )
+        self.assertIs(list, type(data_set))
+        expected_dataset = 2
+        self.assertTrue(
+            data_set_length == expected_dataset,
+            u'Number of datasets is wrong: {0} [expected: {1}, data: {2}]'
+            .format(data_set_length,
+                    expected_dataset,
+                    data_set)
+        )
 
     def test_that_we_can_parse_html_entity_correctly(self):
         """
@@ -212,12 +207,10 @@ class TestXMLExtractor(test_base.TestUnit):
         """
 
         full_text_content = self.extractor.open_xml()
-        #for parser_name in ("html5lib", "html.parser", "lxml-html", "direct-lxml-html", "lxml-xml", "direct-lxml-xml",):
-        for parser_name in ("html5lib", ):
-            self.extractor.parse_xml(preferred_parser_names=(parser_name,))
-            section = self.extractor.extract_string('//body//sec[@id="s2"]//p')
+        self.extractor.parse_xml()
+        section = self.extractor.extract_string('//body//sec[@id="s2"]//p')
 
-            self.assertEqual(section, u'THIS SECTION TESTS HTML ENTITIES LIKE \xc5 >.')
+        self.assertEqual(section, u'THIS SECTION TESTS HTML ENTITIES LIKE \xc5 >.')
 
     def test_that_the_tail_is_preserved(self):
         """
@@ -228,11 +221,10 @@ class TestXMLExtractor(test_base.TestUnit):
         """
 
         full_text_content = self.extractor.open_xml()
-        for parser_name in ("html5lib", "html.parser", "lxml-html", "direct-lxml-html", "lxml-xml", "direct-lxml-xml",):
-            self.extractor.parse_xml(preferred_parser_names=(parser_name,))
-            section = self.extractor.extract_string('//body//sec[@id="s3"]//p')
+        self.extractor.parse_xml()
+        section = self.extractor.extract_string('//body//sec[@id="s3"]//p')
 
-            self.assertEqual(section, u'THIS SECTION TESTS THAT THE TAIL IS PRESERVED .')
+        self.assertEqual(section, u'THIS SECTION TESTS THAT THE TAIL IS PRESERVED .')
 
     def test_that_comments_are_ignored(self):
         """
@@ -242,11 +234,10 @@ class TestXMLExtractor(test_base.TestUnit):
         """
 
         full_text_content = self.extractor.open_xml()
-        for parser_name in ("html5lib", "html.parser", "lxml-html", "direct-lxml-html", "lxml-xml", "direct-lxml-xml",):
-            self.extractor.parse_xml(preferred_parser_names=(parser_name,))
-            section = self.extractor.extract_string('//body//sec[@id="s4"]//p')
+        self.extractor.parse_xml()
+        section = self.extractor.extract_string('//body//sec[@id="s4"]//p')
 
-            self.assertEqual(section, u'THIS SECTION TESTS THAT COMMENTS ARE REMOVED.')
+        self.assertEqual(section, u'THIS SECTION TESTS THAT COMMENTS ARE REMOVED.')
 
     def test_that_cdata_is_removed(self):
         """
@@ -259,11 +250,25 @@ class TestXMLExtractor(test_base.TestUnit):
         """
 
         full_text_content = self.extractor.open_xml()
-        for parser_name in ("html5lib", "html.parser", "lxml-html", "direct-lxml-html", "lxml-xml", "direct-lxml-xml",):
-            self.extractor.parse_xml(preferred_parser_names=(parser_name,))
-            section = self.extractor.extract_string('//body//sec[@id="s5"]//p')
+        self.extractor.parse_xml()
+        section = self.extractor.extract_string('//body//sec[@id="s5"]//p')
 
-            self.assertEqual(section, u'THIS SECTION TESTS THAT CDATA IS REMOVED.')
+        self.assertEqual(section, u'THIS SECTION TESTS THAT CDATA IS REMOVED.')
+
+    def test_that_table_is_extracted_correctly(self):
+        """
+        Tests that the labels/comments for tables are kept while the content of
+        the table is removed. Tables outside of the body field are currently being
+        ignored.
+
+        :return: no return
+        """
+
+        full_text_content = self.extractor.open_xml()
+        self.extractor.parse_xml()
+        section = self.extractor.extract_string('//body//table-wrap')
+
+        self.assertEqual(section, u'TABLE I. TEXT a NOTES a TEXT')
 
 
 class TestTEIXMLExtractor(test_base.TestUnit):
@@ -311,11 +316,10 @@ class TestTEIXMLExtractor(test_base.TestUnit):
         """
 
         full_text_content = self.extractor.open_xml()
-        for parser_name in ("html5lib", "html.parser", "lxml-html", "direct-lxml-html", "lxml-xml", "direct-lxml-xml",):
-            self.extractor.parse_xml(preferred_parser_names=(parser_name,))
-            journal_title = self.extractor.extract_string('//title')
+        self.extractor.parse_xml()
+        journal_title = self.extractor.extract_string('//title')
 
-            self.assertEqual(journal_title, 'ASTRONOMY AND ASTROPHYSICS The NASA Astrophysics Data System: Architecture')
+        self.assertEqual(journal_title, 'ASTRONOMY AND ASTROPHYSICS The NASA Astrophysics Data System: Architecture')
 
     def test_that_we_can_extract_using_settings_template(self):
         """
@@ -327,10 +331,9 @@ class TestTEIXMLExtractor(test_base.TestUnit):
         """
 
         full_text_content = self.extractor.open_xml()
-        for parser_name in ("html5lib", "html.parser", "lxml-html", "direct-lxml-html", "lxml-xml", "direct-lxml-xml",):
-            content = self.extractor.extract_multi_content(preferred_parser_names=(parser_name,))
+        content = self.extractor.extract_multi_content()
 
-            self.assertEqual(rules.META_CONTENT['teixml'].keys(), content.keys())
+        self.assertEqual(rules.META_CONTENT['teixml'].keys(), content.keys())
 
     def test_that_we_can_extract_all_content_from_payload_input(self):
         """
@@ -355,10 +358,9 @@ class TestTEIXMLExtractor(test_base.TestUnit):
         ack = u"Acknowledgements. The usefulness of a bibliographic service is only as good as the quality and quantity of the data it contains . The ADS project has been lucky in benefitting from the skills and dedication of several people who have significantly contributed to the creation and management of the underlying datasets. In particular, we would like to acknowledge the work of Elizabeth Bohlen, Donna Thompson, Markus Demleitner, and Joyce Watson. Funding for this project has been provided by NASA under grant NCC5-189."
 
         full_text_content = self.extractor.open_xml()
-        for parser_name in ("html5lib", "html.parser", "lxml-html", "direct-lxml-html", "lxml-xml", "direct-lxml-xml",):
-            content = self.extractor.extract_multi_content(preferred_parser_names=(parser_name,))
+        content = self.extractor.extract_multi_content()
 
-            self.assertEqual(content['acknowledgements'], ack)
+        self.assertEqual(content['acknowledgements'], ack)
 
 
 
@@ -408,10 +410,9 @@ class TestXMLElsevierExtractor(test_base.TestUnit):
         """
 
         full_text_content = self.extractor.open_xml()
-        for parser_name in ("html5lib", "html.parser", "lxml-html", "direct-lxml-html", "lxml-xml", "direct-lxml-xml",):
-            self.extractor.parse_xml(preferred_parser_names=(parser_name,))
-            journal_title = self.extractor.extract_string('//*[local-name()=\'title\']')
-            self.assertIn('JOURNAL TITLE', journal_title)
+        self.extractor.parse_xml()
+        journal_title = self.extractor.extract_string('//*[local-name()=\'title\']')
+        self.assertIn('JOURNAL TITLE', journal_title)
 
     def test_that_we_can_extract_using_settings_template(self):
         """
@@ -423,14 +424,13 @@ class TestXMLElsevierExtractor(test_base.TestUnit):
         """
 
         full_text_content = self.extractor.open_xml()
-        for parser_name in ("html5lib", "html.parser", "lxml-html", "direct-lxml-html", "lxml-xml", "direct-lxml-xml",):
-            content = self.extractor.extract_multi_content(preferred_parser_names=(parser_name,))
+        content = self.extractor.extract_multi_content()
 
-            self.assertItemsEqual(['fulltext', 'acknowledgements', 'dataset'],
-                                  content.keys(),
-                                  content.keys())
+        self.assertItemsEqual(['fulltext', 'acknowledgements', 'dataset'],
+                              content.keys(),
+                              content.keys())
 
-            self.assertIn('JOURNAL CONTENT', content['fulltext'])
+        self.assertIn('JOURNAL CONTENT', content['fulltext'])
 
     def test_that_the_correct_extraction_is_used_for_the_datatype(self):
         """
@@ -462,35 +462,34 @@ class TestXMLElsevierExtractor(test_base.TestUnit):
 
         self.dict_item['bibcode'] = 'test'
         full_text_content = self.extractor.open_xml()
-        for parser_name in ("html5lib", "html.parser", "lxml-html", "direct-lxml-html", "lxml-xml", "direct-lxml-xml",):
-            content = self.extractor.extract_multi_content(preferred_parser_names=(parser_name,))
+        content = self.extractor.extract_multi_content()
 
-            full_text = content['fulltext']
-            acknowledgements = content['acknowledgements']
-            data_set = content['dataset']
-            data_set_length = len(data_set)
+        full_text = content['fulltext']
+        acknowledgements = content['acknowledgements']
+        data_set = content['dataset']
+        data_set_length = len(data_set)
 
-            self.assertIs(unicode, type(acknowledgements))
+        self.assertIs(unicode, type(acknowledgements))
 
-            self.assertIs(unicode, type(full_text))
-            expected_full_text = 'CONTENT'
-            self.assertTrue(
-                expected_full_text in full_text,
-                u'Full text is wrong: {0} [expected: {1}, data: {2}]'
-                .format(full_text,
-                        expected_full_text,
-                        full_text)
-            )
+        self.assertIs(unicode, type(full_text))
+        expected_full_text = 'CONTENT'
+        self.assertTrue(
+            expected_full_text in full_text,
+            u'Full text is wrong: {0} [expected: {1}, data: {2}]'
+            .format(full_text,
+                    expected_full_text,
+                    full_text)
+        )
 
-            self.assertIs(list, type(data_set))
-            expected_dataset = 2
-            self.assertTrue(
-                data_set_length == expected_dataset,
-                u'Number of datasets is wrong: {0} [expected: {1}, data: {2}]'
-                .format(data_set_length,
-                        expected_dataset,
-                        data_set)
-            )
+        self.assertIs(list, type(data_set))
+        expected_dataset = 2
+        self.assertTrue(
+            data_set_length == expected_dataset,
+            u'Number of datasets is wrong: {0} [expected: {1}, data: {2}]'
+            .format(data_set_length,
+                    expected_dataset,
+                    data_set)
+        )
 
 
 class TestHTMLExtractor(test_base.TestUnit):

--- a/adsft/tests/test_extraction.py
+++ b/adsft/tests/test_extraction.py
@@ -28,7 +28,6 @@ class TestXMLExtractor(test_base.TestUnit):
                           'provider': 'MNRAS'}
         self.extractor = extraction.EXTRACTOR_FACTORY['xml'](self.dict_item)
         self.parsers = ("lxml-xml", "html.parser", "lxml-html", "direct-lxml-html", "direct-lxml-xml", "html5lib",)
-        self.maxDiff = None
 
     def test_that_we_can_open_an_xml_file(self):
         """

--- a/adsft/tests/test_extraction.py
+++ b/adsft/tests/test_extraction.py
@@ -320,7 +320,8 @@ class TestXMLExtractor(test_base.TestUnit):
                 u"III. SECTION III THIS SECTION TESTS THAT THE TAIL IS PRESERVED . "
                 u"IV. SECTION IV THIS SECTION TESTS THAT COMMENTS ARE REMOVED. "
                 u"V. SECTION V THIS SECTION TESTS THAT CDATA IS REMOVED. "
-                u"Manual Entry 1 Manual Entry 2 TABLE I. TEXT a NOTES a TEXT")
+                u"Manual Entry 1 Manual Entry 2 TABLE I. TEXT a NOTES a TEXT"
+            )
 
 
 class TestTEIXMLExtractor(test_base.TestUnit):
@@ -542,6 +543,48 @@ class TestXMLElsevierExtractor(test_base.TestUnit):
                     expected_dataset,
                     data_set)
         )
+
+    def test_that_we_can_parse_html_entity_correctly(self):
+        """
+        Tests the parse_xml method. Checks that the HTML entities are parsed
+        without errors caused by escaped ambersands.
+
+        :return: no return
+        """
+
+        full_text_content = self.extractor.open_xml()
+        self.extractor.parse_xml()
+        section = self.extractor.extract_string('//body//section[@id="s2"]//para')
+
+        self.assertEqual(section, u'THIS SECTION TESTS HTML ENTITIES LIKE \xc5 >.')
+
+    def test_that_the_tail_is_preserved(self):
+        """
+        Tests that when a tag is removed any trailing text is preserved by appending
+        it to the previous or parent element.
+
+        :return: no return
+        """
+
+        full_text_content = self.extractor.open_xml()
+        self.extractor.parse_xml()
+        section = self.extractor.extract_string('//body//section[@id="s3"]//para')
+
+        self.assertEqual(section, u'THIS SECTION TESTS THAT THE TAIL IS PRESERVED .')
+
+    def test_that_comments_are_ignored(self):
+        """
+        Tests that parsing the xml file ignores any comments like <!-- example comment -->.
+
+        :return: no return
+        """
+
+        full_text_content = self.extractor.open_xml()
+        self.extractor.parse_xml()
+        section = self.extractor.extract_string('//body//section[@id="s4"]//para')
+
+        self.assertEqual(section, u'THIS SECTION TESTS THAT COMMENTS ARE REMOVED.')
+
 
 
 class TestHTMLExtractor(test_base.TestUnit):

--- a/adsft/tests/test_extraction.py
+++ b/adsft/tests/test_extraction.py
@@ -424,7 +424,7 @@ class TestXMLExtractor(test_base.TestUnit):
                 u"Manual Entry 1 Manual Entry 2 TABLE I. TEXT a NOTES a TEXT"
             )
 
-    def test_that_we_can_extract_acknowledgments_when_inside(self):
+    def test_that_we_can_extract_acknowledgments_when_inside_body(self):
 
         """
         This checks that acknowledgments within the body tag are removed

--- a/adsft/tests/test_extraction.py
+++ b/adsft/tests/test_extraction.py
@@ -305,6 +305,22 @@ class TestXMLExtractor(test_base.TestUnit):
                 u"V. SECTION V THIS SECTION TESTS THAT CDATA IS REMOVED. " + s
             )
 
+    def test_handling_of_parsers_that_detect_namespaces(self):
+
+        full_text_content = self.extractor.open_xml()
+
+        for parser_name in ["lxml-xml", "direct-lxml-xml"]:
+
+            self.extractor.parse_xml(preferred_parser_names=(parser_name,))
+
+            section = self.extractor.extract_string('//body')
+
+            self.assertEqual(section, u"I. INTRODUCTION INTRODUCTION GOES HERE "
+                u"II. SECTION II THIS SECTION TESTS HTML ENTITIES LIKE \xc5 >. "
+                u"III. SECTION III THIS SECTION TESTS THAT THE TAIL IS PRESERVED . "
+                u"IV. SECTION IV THIS SECTION TESTS THAT COMMENTS ARE REMOVED. "
+                u"V. SECTION V THIS SECTION TESTS THAT CDATA IS REMOVED. "
+                u"Manual Entry 1 Manual Entry 2 TABLE I. TEXT a NOTES a TEXT")
 
 
 class TestTEIXMLExtractor(test_base.TestUnit):

--- a/adsft/tests/test_extraction.py
+++ b/adsft/tests/test_extraction.py
@@ -711,7 +711,7 @@ class TestXMLElsevierExtractor(test_base.TestUnit):
         full_text_content = self.extractor.open_xml()
 
         if self.parsers:
-            for parser_name in ("lxml-xml",): # this is the only parser that works for this unit test
+            for parser_name in self.parsers:
                 self.extractor.parse_xml(preferred_parser_names=(parser_name,))
                 section = self.extractor.extract_string('//body//section[@id="s3"]//para')
                 self.assertEqual(section, u'THIS SECTION TESTS THAT THE TAIL IS PRESERVED .')

--- a/adsft/tests/test_full_range_of_formats.py
+++ b/adsft/tests/test_full_range_of_formats.py
@@ -133,7 +133,7 @@ class TestFullRangeFormatExtraction(test_base.TestGeneric):
                 expected_fulltext_content = (
                         u"Introduction THIS IS AN INTERESTING TITLE",
                         u"Introduction THIS IS AN INTERESTING TITLE",
-                        u"I. INTRODUCTION INTRODUCTION GOES HERE Manual Entry\nAPPENDIX: APPENDIX TITLE GOES HERE APPENDIX CONTENT",
+                        u"I. INTRODUCTION INTRODUCTION GOES HERE Manual Entry TABLE I. TEXT a NOTES a TEXT\nAPPENDIX: APPENDIX TITLE GOES HERE APPENDIX CONTENT",
                         u'1 Introduction JOURNAL CONTENT Acknowledgments THANK YOU Appendix A APPENDIX TITLE APPENDIX',
                         u"No Title AA 999, 999-999 (1999) DOI: 99.9999/9999-9999:99999999 TITLE AUTHOR AFFILIATION Received 99 MONTH 1999 / Accepted 99 MONTH 1999 Abstract ABSTRACT Key words: KEYWORD INTRODUCTION SECTION Table 1: TABLE TABLE (1) COPYRIGHT",
                         #u"Introduction\nTHIS IS AN INTERESTING TITLE\n", # PDFBox

--- a/adsft/tests/test_tasks.py
+++ b/adsft/tests/test_tasks.py
@@ -79,7 +79,7 @@ class TestWorkers(unittest.TestCase):
                 self.assertTrue(task_write_text.called)
                 actual = task_write_text.call_args[0][0]
 
-                self.assertEqual(u'I. INTRODUCTION INTRODUCTION GOES HERE Manual Entry\nAPPENDIX: APPENDIX TITLE GOES HERE APPENDIX CONTENT', actual['fulltext'])
+                self.assertEqual(u'I. INTRODUCTION INTRODUCTION GOES HERE Manual Entry TABLE I. TEXT a NOTES a TEXT\nAPPENDIX: APPENDIX TITLE GOES HERE APPENDIX CONTENT', actual['fulltext'])
                 self.assertEqual(u'Acknowledgments WE ACKNOWLEDGE.', actual['acknowledgements'])
                 self.assertEqual([u'ADS/Sa.CXO#Obs/11458'], actual['dataset'])
                 self.assertTrue(task_output_results.called)

--- a/config.py
+++ b/config.py
@@ -12,6 +12,7 @@ EXTRACT_PDF_SCRIPT = '/scripts/extract_pdf_with_pdftotext.sh'
 OUTPUT_CELERY_BROKER = 'pyamqp://guest:guest@localhost:6672/master_pipeline'
 OUTPUT_TASKNAME = 'adsmp.tasks.task_update_record'
 
+PREFERRED_XML_PARSER_NAMES = ("html5lib", "html.parser", "lxml-html", "direct-lxml-html", "lxml-xml", "direct-lxml-xml",)
 
 FULLTEXT_EXTRACT_PATH = './live'
 

--- a/tests/test_integration/stub_data/full_test.xml
+++ b/tests/test_integration/stub_data/full_test.xml
@@ -104,6 +104,43 @@
             <named-content content-type="dataset" xlink:href="ADS/Sa.CXO#Obs/11458">Manual Entry</named-content>
         </data>
 
+        <table-wrap id="t1" orientation="portrait" position="float">
+          <label>TABLE I.</label>
+          <caption>
+              <p>TEXT<xref ref-type="table-fn" rid="t1n1"><sup>a</sup></xref></p>
+           </caption>
+           <table border="1">
+              <colgroup span="1">
+                 <col align="left" span="1"/>
+              </colgroup>
+              <thead>
+                 <tr>
+                    <th colspan="1" rowspan="1"><italic>CONTENT</italic></th>
+                    <th align="center" colspan="1" rowspan="1">CONTENT</th>
+                 </tr>
+              </thead>
+              <tbody>
+                 <tr>
+                    <td colspan="1" rowspan="1">1</td>
+                    <td align="center" colspan="1" rowspan="1">CONTENT</td>
+                 </tr>
+              </tbody>
+           </table>
+           <graphic xlink:href="apj523416t3_tb.gif"/>
+           <graphic xlink:href="apj523416t3_lr.gif"><caption><p>1</p></caption></graphic>
+           <graphic xlink:href="apj523416t3a_tb.gif"/>
+           <graphic xlink:href="apj523416t3a_lr.gif"><caption><p>2</p></caption></graphic>
+           <graphic xlink:href="apj523416t3b_tb.gif"/>
+           <graphic xlink:href="apj523416t3b_lr.gif"><caption><p>3</p></caption></graphic>
+           <table-wrap-foot>
+             <p><bold>NOTES</bold></p>
+             <fn id="t1n1">
+               <label><sup>a</sup></label>
+               <p>TEXT</p>
+             </fn>
+           </table-wrap-foot>
+        </table-wrap>
+
    </body>
 
     <back>
@@ -132,8 +169,8 @@
          <graphic orientation="portrait" position="float" xlink:href="f1"/>
       </fig>
 
-      <table-wrap id="t1" orientation="portrait" position="float"><label>TABLE I.</label><caption>
-            <p>TEXT<xref ref-type="table-fn" rid="t1n1"><sup>a</sup></xref></p>
+      <table-wrap id="t2" orientation="portrait" position="float"><label>TABLE II.</label><caption>
+            <p>TEXT<xref ref-type="table-fn" rid="t2n1"><sup>a</sup></xref></p>
          </caption>
          <table border="1">
             <colgroup span="1">
@@ -152,6 +189,6 @@
                </tr>
             </tbody>
          </table>
-         <table-wrap-foot><fn id="t1n1"><label><sup>a</sup></label><p>TEXT</p></fn></table-wrap-foot>
+         <table-wrap-foot><fn id="t2n1"><label><sup>a</sup></label><p>TEXT</p></fn></table-wrap-foot>
       </table-wrap>
    </floats-group></article>

--- a/tests/test_unit/stub_data/test.xml
+++ b/tests/test_unit/stub_data/test.xml
@@ -120,6 +120,43 @@
             <named-content content-type="dataset" xlink:href="ADS/Sa.CXO#Obs/11459">Manual Entry 2</named-content>
         </data>
 
+        <table-wrap id="t1" orientation="portrait" position="float">
+          <label>TABLE I.</label>
+          <caption>
+              <p>TEXT<xref ref-type="table-fn" rid="t1n1"><sup>a</sup></xref></p>
+           </caption>
+           <table border="1">
+              <colgroup span="1">
+                 <col align="left" span="1"/>
+              </colgroup>
+              <thead>
+                 <tr>
+                    <th colspan="1" rowspan="1"><italic>CONTENT</italic></th>
+                    <th align="center" colspan="1" rowspan="1">CONTENT</th>
+                 </tr>
+              </thead>
+              <tbody>
+                 <tr>
+                    <td colspan="1" rowspan="1">1</td>
+                    <td align="center" colspan="1" rowspan="1">CONTENT</td>
+                 </tr>
+              </tbody>
+           </table>
+           <graphic xlink:href="apj523416t3_tb.gif"/>
+           <graphic xlink:href="apj523416t3_lr.gif"><caption><p>1</p></caption></graphic>
+           <graphic xlink:href="apj523416t3a_tb.gif"/>
+           <graphic xlink:href="apj523416t3a_lr.gif"><caption><p>2</p></caption></graphic>
+           <graphic xlink:href="apj523416t3b_tb.gif"/>
+           <graphic xlink:href="apj523416t3b_lr.gif"><caption><p>3</p></caption></graphic>
+           <table-wrap-foot>
+             <p><bold>NOTES</bold></p>
+             <fn id="t1n1">
+               <label><sup>a</sup></label>
+               <p>TEXT</p>
+             </fn>
+           </table-wrap-foot>
+        </table-wrap>
+
    </body>
 
     <back>
@@ -148,8 +185,8 @@
          <graphic orientation="portrait" position="float" xlink:href="f1"/>
       </fig>
 
-      <table-wrap id="t1" orientation="portrait" position="float"><label>TABLE I.</label><caption>
-            <p>TEXT<xref ref-type="table-fn" rid="t1n1"><sup>a</sup></xref></p>
+      <table-wrap id="t2" orientation="portrait" position="float"><label>TABLE II.</label><caption>
+            <p>TEXT<xref ref-type="table-fn" rid="t2n1"><sup>a</sup></xref></p>
          </caption>
          <table border="1">
             <colgroup span="1">
@@ -168,6 +205,6 @@
                </tr>
             </tbody>
          </table>
-         <table-wrap-foot><fn id="t1n1"><label><sup>a</sup></label><p>TEXT</p></fn></table-wrap-foot>
+         <table-wrap-foot><fn id="t2n1"><label><sup>a</sup></label><p>TEXT</p></fn></table-wrap-foot>
       </table-wrap>
    </floats-group></article>

--- a/tests/test_unit/stub_data/test.xml
+++ b/tests/test_unit/stub_data/test.xml
@@ -156,7 +156,10 @@
              </fn>
            </table-wrap-foot>
         </table-wrap>
-
+        <ack>
+          <title>Acknowledgments</title>
+          <p>WE ACKNOWLEDGE.</p>
+        </ack>
    </body>
 
     <back>

--- a/tests/test_unit/stub_data/test_elsevier.xml
+++ b/tests/test_unit/stub_data/test_elsevier.xml
@@ -102,9 +102,18 @@
 
         <ja:body view="all">
         <ce:sections>
-            <ce:section id="s0005" view="all"><ce:label>1</ce:label>
-                <ce:section-title id="st0020">Introduction</ce:section-title>
-                <ce:para id="p0005" view="all">JOURNAL CONTENT</ce:para>
+            <ce:section id="s1" view="all"><ce:label>I.</ce:label><ce:section-title>INTRODUCTION</ce:section-title>
+                <ce:para>JOURNAL CONTENT <ce:formula>this should be removed</ce:formula>GOES HERE</ce:para>
+            </ce:section>
+            <ce:section id="s2" view="all"><ce:label>II.</ce:label><ce:section-title>SECTION II</ce:section-title>
+               <ce:para>THIS SECTION TESTS HTML ENTITIES LIKE &angst; &amp; &gt;.</ce:para>
+            </ce:section>
+            <ce:section id="s3" view="all"><ce:label>III.</ce:label><ce:section-title>SECTION III</ce:section-title>
+               <ce:para>THIS SECTION TESTS THAT THE <ce:formula>formula</ce:formula>TAIL <ce:italic>IS PRESERVED</ce:italic>.</ce:para>
+            </ce:section>
+            <ce:section id="s4" view="all"><ce:label>IV.</ce:label><ce:section-title>SECTION IV</ce:section-title>
+               <ce:para>THIS SECTION TESTS <!-- THIS SHOULD BE REMOVED -->THAT COMMENTS ARE REMOVED.</ce:para>
+            </ce:section>
             </ce:section>
         </ce:sections>
 


### PR DESCRIPTION
Addressing issue #18 where acknowledgement tag is within the body tag, now acknowledgements are always moved outside of the body tag. The parsers were also rearranged as "html5lib" in bs4 does not remove certain tables like in the article referenced in this issue (2012MNRAS.419.3018C). When using this parser it only recognizes thead and tbody tags, all other nested tags are not recognized as children and are consequently not removed.  

This PR will also fix a problem where notes in a table footer are not extracted properly, an example of this is found in 2016ApJ...824…58D where a note in the Table 3 footer including "2MASS" is missing when html5lib is used. The reason the html5lib parser fails in extracting certain parts of the table footer is because of graphic tags that do not have closing tags, the parser tries to reconcile these and places closing graphic tags somewhere in or after the table footer and the graphic tag and its contents are then removed along with all or part of the table footer.