### PR TITLE
replace nested task calls with celery chain

### DIFF
--- a/run.py
+++ b/run.py
@@ -92,7 +92,11 @@ def run(full_text_links, **kwargs):
         if diagnose:
             print("[{}/{}] Calling 'task_check_if_extract' with '{}'".format(i+1, total, str(record)))
         logger.debug("[%i/%i] Calling 'task_check_if_extract' with '%s'", i+1, total, str(record))
-        tasks.task_check_if_extract.delay(record)
+        chain(
+            tasks.task_check_if_extract(record),
+            tasks.task_extract.si(),
+            tasks.task_output_results.si()
+        ).delay()
         #tasks.task_check_if_extract(record) # Treat synchronously to avoid saturating NFS mount access
         i += 1
 


### PR DESCRIPTION
Celery chains are a type of workflow object defined in the documentation [here](https://docs.celeryproject.org/en/latest/userguide/canvas.html#chains) that allows us to run tasks sequentially. We can use the .s() or si() functions to pass the return value of the current task to the next task, in our case this would be the msg variable. See an example of what I am describing [here](https://gist.github.com/codeinthehole/4124910).  