### PR TITLE
fix bug introduced in last release, impacting certain xml files

### DIFF
--- a/adsft/extraction.py
+++ b/adsft/extraction.py
@@ -453,6 +453,7 @@ class StandardExtractorXML(object):
         """
         move tag outside/after the parent tag so it is now a sibling
         """
+
         parent = node.getparent()
 
         if parent != None:
@@ -713,8 +714,7 @@ class StandardExtractorXML(object):
 
         # move facilities out of acknowledgments
         for e in parsed_xml.xpath(" | ".join(META_CONTENT['xml']['facility']['xpath'])):
-            self._append_tag_outside_parent(e.getparent())
-
+            self._append_tag_outside_parent(e)
 
 
         return parsed_xml

--- a/adsft/tests/test_extraction.py
+++ b/adsft/tests/test_extraction.py
@@ -341,13 +341,19 @@ class TestXMLExtractor(TestXMLExtractorBase):
         This tests that we can extract the faciltites field.
         :return: no return
         """
-        facility = [u'FacilityName']
+        facilities = [u'FacilityName1',
+                        u'FacilityName2',
+                        u'FacilityName3',
+                        u'FacilityName4',
+                        u'FacilityName5',
+                        u'FacilityName6',
+                        u'FacilityName7']
 
         full_text_content = self.extractor.open_xml()
 
         for parser_name in self.preferred_parser_names:
             content = self.extractor.extract_multi_content(preferred_parser_names=(parser_name,))
-            self.assertEqual(content['facility'], facility)
+            self.assertEqual(sorted(content['facility']), facilities)
 
 class TestTEIXMLExtractor(TestXMLExtractorBase):
     """

--- a/tests/test_unit/stub_data/test.xml
+++ b/tests/test_unit/stub_data/test.xml
@@ -166,7 +166,15 @@
       <ack>
          <title>Acknowledgments</title>
          <p>WE ACKNOWLEDGE.</p></ack>
-      <p><italic>Facility:</italic> <named-content content-type="facility" xlink:href="FacilityName"><italic>FacilityName</italic></named-content>.</p>
+      <p><italic>Facilities:</italic>
+        <named-content content-type="facility" xlink:href="FacilityName1">FacilityName1</named-content>,
+        <named-content content-type="facility" xlink:href="FacilityName2">FacilityName2</named-content>,
+        <named-content content-type="facility" xlink:href="FacilityName3">FacilityName3</named-content>,
+        <named-content content-type="facility" xlink:href="FacilityName4">FacilityName4</named-content>,
+        <named-content content-type="facility" xlink:href="FacilityName5">FacilityName5</named-content>,
+        <named-content content-type="facility" xlink:href="FacilityName6">FacilityName6</named-content>,
+        <named-content content-type="facility" xlink:href="FacilityName7">FacilityName7</named-content>
+      </p>
       <app-group>
          <app id="app1">
             <title>APPENDIX: APPENDIX TITLE GOES HERE</title>


### PR DESCRIPTION
This effected xml files that were wrapped in root tags during extraction and had more than one facility, see this bibcode for example: 2011AJ....142..149N

Unit test updated to catch this type of error. 