### PR TITLE
stop removing facilities from acknowledgements

### DIFF
--- a/adsft/extraction.py
+++ b/adsft/extraction.py
@@ -712,11 +712,6 @@ class StandardExtractorXML(object):
         for e in parsed_xml.xpath(" | ".join(META_CONTENT['xml']['acknowledgements']['xpath'])):
             self._append_tag_outside_parent(e)
 
-        # move facilities out of acknowledgments
-        for e in parsed_xml.xpath(" | ".join(META_CONTENT['xml']['facility']['xpath'])):
-            self._append_tag_outside_parent(e)
-
-
         return parsed_xml
 
     def extract_string(self, static_xpath, **kwargs):

--- a/adsft/tests/test_extraction.py
+++ b/adsft/tests/test_extraction.py
@@ -324,17 +324,25 @@ class TestXMLExtractor(TestXMLExtractorBase):
             )
 
 
-    def test_that_we_can_extract_acknowledgments_when_inside_body(self):
+    def test_extraction_of_acknowledgments(self):
 
         """
-        This checks that acknowledgments within the body tag are removed
+        This tests that acknowledgments are extracted, acknowledgments should include the
+        facilities as of issue #100 in github. There are cases in which the acknowledgments
+        are found inside the body tag, but the body tag should not include the acknowledgments
+        as of issue #18. An acknowledgement field is included in the body tag in test.xml to
+        test that these are being moved outside of the body tag, which is why we see 'ACK
+        INSIDE BODY TAG.' appended to this acknowledgment.
+
         :return: no return
         """
         full_text_content = self.extractor.open_xml()
 
         for parser_name in self.preferred_parser_names:
             content = self.extractor.extract_multi_content(preferred_parser_names=(parser_name,))
-            self.assertEqual(content['acknowledgements'], u"Acknowledgments WE ACKNOWLEDGE.")
+            self.assertEqual(content['acknowledgements'], u"Acknowledgments WE ACKNOWLEDGE. Facilities: FacilityName1 , "
+                                                            "FacilityName2 , FacilityName3 , FacilityName4 , FacilityName5 , "
+                                                            "FacilityName6 , FacilityName7\nACK INSIDE BODY TAG.")
 
     def test_extraction_of_facilities(self):
         """

--- a/tests/test_unit/stub_data/test.xml
+++ b/tests/test_unit/stub_data/test.xml
@@ -156,25 +156,23 @@
              </fn>
            </table-wrap-foot>
         </table-wrap>
-        <ack>
-          <title>Acknowledgments</title>
-          <p>WE ACKNOWLEDGE.</p>
-        </ack>
+        <section type="acknowledgments"><p>ACK INSIDE BODY TAG.</p></section>
    </body>
 
     <back>
       <ack>
          <title>Acknowledgments</title>
-         <p>WE ACKNOWLEDGE.</p></ack>
-      <p><italic>Facilities:</italic>
-        <named-content content-type="facility" xlink:href="FacilityName1">FacilityName1</named-content>,
-        <named-content content-type="facility" xlink:href="FacilityName2">FacilityName2</named-content>,
-        <named-content content-type="facility" xlink:href="FacilityName3">FacilityName3</named-content>,
-        <named-content content-type="facility" xlink:href="FacilityName4">FacilityName4</named-content>,
-        <named-content content-type="facility" xlink:href="FacilityName5">FacilityName5</named-content>,
-        <named-content content-type="facility" xlink:href="FacilityName6">FacilityName6</named-content>,
-        <named-content content-type="facility" xlink:href="FacilityName7">FacilityName7</named-content>
-      </p>
+         <p>WE ACKNOWLEDGE.</p>
+         <p><italic>Facilities:</italic>
+           <named-content content-type="facility" xlink:href="FacilityName1">FacilityName1</named-content>,
+           <named-content content-type="facility" xlink:href="FacilityName2">FacilityName2</named-content>,
+           <named-content content-type="facility" xlink:href="FacilityName3">FacilityName3</named-content>,
+           <named-content content-type="facility" xlink:href="FacilityName4">FacilityName4</named-content>,
+           <named-content content-type="facility" xlink:href="FacilityName5">FacilityName5</named-content>,
+           <named-content content-type="facility" xlink:href="FacilityName6">FacilityName6</named-content>,
+           <named-content content-type="facility" xlink:href="FacilityName7">FacilityName7</named-content>
+         </p>
+       </ack>
       <app-group>
          <app id="app1">
             <title>APPENDIX: APPENDIX TITLE GOES HERE</title>


### PR DESCRIPTION
This addresses issue #100 

Please note: In the case that the facilities are located outside of the acknowledgments, they are not appended to the acknowledgments.   