### PR TITLE
ignore facilities without xlink:href

### DIFF
--- a/adsft/extraction.py
+++ b/adsft/extraction.py
@@ -813,7 +813,7 @@ class StandardExtractorXML(object):
 
                 # to ignore facility tags missing xlink:href
                 # https://github.com/adsabs/ADSfulltext/issues/107
-                if text_content == 'None':
+                if text_content == 'None' or text_content == '':
                     continue
 
                 data_inner.append(text_content)

--- a/adsft/extraction.py
+++ b/adsft/extraction.py
@@ -798,7 +798,7 @@ class StandardExtractorXML(object):
                     # tags/attributes to namespace:name (e.g., {http://www.w3.org/1999/xlink}href)
                     # while others will keep the prefix (e.g., xlink:href)
                     # Our processing removes the namespace expansion and the
-                    # prefix (e.g., href), thus, if the attribute name in the ruls
+                    # prefix (e.g., href), thus, if the attribute name in the rules
                     # contains a namespace prefix, we need to remove it:
                     vspan_content = span_content.split(":")
                     if len(vspan_content) >= 2:
@@ -810,6 +810,11 @@ class StandardExtractorXML(object):
                     translate=translate,
                     normalise=True,
                     trim=True)
+
+                # to ignore facility tags missing xlink:href
+                # https://github.com/adsabs/ADSfulltext/issues/107
+                if text_content == 'None':
+                    continue
 
                 data_inner.append(text_content)
             except KeyError:

--- a/adsft/tests/test_extraction.py
+++ b/adsft/tests/test_extraction.py
@@ -349,12 +349,12 @@ class TestXMLExtractor(TestXMLExtractorBase):
         """
         This tests that we can extract the faciltites field.The first facility is
         a test to make sure we are not extracting facilities where the xlink:href is
-        missing. This is discussed here: https://github.com/adsabs/ADSfulltext/issues/107
+        missing, and the second facilities where xlink:href is empty. This is
+        discussed here: https://github.com/adsabs/ADSfulltext/issues/107
 
         :return: no return
         """
-        facilities = [u'FacilityID2',
-                        u'FacilityID3',
+        facilities = [u'FacilityID3',
                         u'FacilityID4',
                         u'FacilityID5',
                         u'FacilityID6',

--- a/adsft/tests/test_extraction.py
+++ b/adsft/tests/test_extraction.py
@@ -347,16 +347,18 @@ class TestXMLExtractor(TestXMLExtractorBase):
     def test_extraction_of_facilities(self):
 
         """
-        This tests that we can extract the faciltites field.
+        This tests that we can extract the faciltites field.The first facility is
+        a test to make sure we are not extracting facilities where the xlink:href is
+        missing. This is discussed here: https://github.com/adsabs/ADSfulltext/issues/107
+
         :return: no return
         """
-        facilities = [u'FacilityName1',
-                        u'FacilityName2',
-                        u'FacilityName3',
-                        u'FacilityName4',
-                        u'FacilityName5',
-                        u'FacilityName6',
-                        u'FacilityName7']
+        facilities = [u'FacilityID2',
+                        u'FacilityID3',
+                        u'FacilityID4',
+                        u'FacilityID5',
+                        u'FacilityID6',
+                        u'FacilityID7']
 
         full_text_content = self.extractor.open_xml()
 

--- a/tests/test_unit/stub_data/test.xml
+++ b/tests/test_unit/stub_data/test.xml
@@ -167,7 +167,7 @@
          <p>WE ACKNOWLEDGE.</p>
          <p><italic>Facilities:</italic>
            <named-content content-type="facility">FacilityName1</named-content>,
-           <named-content content-type="facility" xlink:href="FacilityID2">FacilityName2</named-content>,
+           <named-content content-type="facility" xlink:href="">FacilityName2</named-content>,
            <named-content content-type="facility" xlink:href="FacilityID3">FacilityName3</named-content>,
            <named-content content-type="facility" xlink:href="FacilityID4">FacilityName4</named-content>,
            <named-content content-type="facility" xlink:href="FacilityID5">FacilityName5</named-content>,

--- a/tests/test_unit/stub_data/test.xml
+++ b/tests/test_unit/stub_data/test.xml
@@ -166,13 +166,13 @@
          <title>Acknowledgments</title>
          <p>WE ACKNOWLEDGE.</p>
          <p><italic>Facilities:</italic>
-           <named-content content-type="facility" xlink:href="FacilityName1">FacilityName1</named-content>,
-           <named-content content-type="facility" xlink:href="FacilityName2">FacilityName2</named-content>,
-           <named-content content-type="facility" xlink:href="FacilityName3">FacilityName3</named-content>,
-           <named-content content-type="facility" xlink:href="FacilityName4">FacilityName4</named-content>,
-           <named-content content-type="facility" xlink:href="FacilityName5">FacilityName5</named-content>,
-           <named-content content-type="facility" xlink:href="FacilityName6">FacilityName6</named-content>,
-           <named-content content-type="facility" xlink:href="FacilityName7">FacilityName7</named-content>
+           <named-content content-type="facility">FacilityName1</named-content>,
+           <named-content content-type="facility" xlink:href="FacilityID2">FacilityName2</named-content>,
+           <named-content content-type="facility" xlink:href="FacilityID3">FacilityName3</named-content>,
+           <named-content content-type="facility" xlink:href="FacilityID4">FacilityName4</named-content>,
+           <named-content content-type="facility" xlink:href="FacilityID5">FacilityName5</named-content>,
+           <named-content content-type="facility" xlink:href="FacilityID6">FacilityName6</named-content>,
+           <named-content content-type="facility" xlink:href="FacilityID7">FacilityName7</named-content>
          </p>
        </ack>
       <app-group>


### PR DESCRIPTION
This addresses issue #107. 

As a result of this modification, dataset tags with missing or empty `xlink:href` will also be ignored. 