### PR TITLE
specifically target and remove CDATA PIs

### DIFF
--- a/adsft/extraction.py
+++ b/adsft/extraction.py
@@ -489,6 +489,11 @@ class StandardExtractorXML(object):
         # Notes:
         #   - no parser provides a reliable way to find CDATA and remove their content
         #     Source: https://stackoverflow.com/a/44561547
+        if parser_name in ("html5lib", "html.parser", "lxml-html", "direct-lxml-html"):
+            # CDATA in Processing Instruction form, can include '>' symbol
+            # which will break Processing Instruction regex below
+            raw_xml = re.sub('<\?CDATA[\s\S\n]*?\?>', '', raw_xml)
+
         if parser_name in ("lxml-html", "html.parser", "html5lib"):
             # - A processing instruction is coded like this: <?ignore .... what ever I want here, including <!-- comments --> ...  ?>
             #   RegEx Source: https://stackoverflow.com/a/29418829/6940788

--- a/adsft/extraction.py
+++ b/adsft/extraction.py
@@ -490,14 +490,11 @@ class StandardExtractorXML(object):
         #   - no parser provides a reliable way to find CDATA and remove their content
         #     Source: https://stackoverflow.com/a/44561547
         if parser_name in ("html5lib", "html.parser", "lxml-html", "direct-lxml-html"):
-            # CDATA in Processing Instruction form, can include '>' symbol
-            # which will break Processing Instruction regex below
-            raw_xml = re.sub('<\?CDATA[\s\S\n]*?\?>', '', raw_xml)
-
-        if parser_name in ("lxml-html", "html.parser", "html5lib"):
+            # - CDATA in Processing Instruction form, can include '>' symbol
+            #   which will break Processing Instruction regex in the link below
             # - A processing instruction is coded like this: <?ignore .... what ever I want here, including <!-- comments --> ...  ?>
             #   RegEx Source: https://stackoverflow.com/a/29418829/6940788
-            raw_xml = re.sub('<\?[^>]+\?>', '', raw_xml) # Processing instructions
+            raw_xml = re.sub('<\?[\s\S\n]*?\?>', '', raw_xml) # Processing instructions
         if parser_name in ("html5lib",):
             # - Convert self closing xml tags to closing tags
             #   Source: https://stackoverflow.com/a/14028108

--- a/tests/test_unit/stub_data/test.xml
+++ b/tests/test_unit/stub_data/test.xml
@@ -109,7 +109,7 @@
          <p>THIS SECTION TESTS <!-- THIS SHOULD BE REMOVED -->THAT COMMENTS ARE REMOVED.</p>
       </sec>
       <sec id="s5"><label>V.</label><title>SECTION V</title>
-          <p><?CDATA THIS SHOULD BE REMOVED ?>THIS SECTION TESTS <![CDATA[
+          <p><?CDATA THIS SHOULD > BE REMOVED ?>THIS SECTION TESTS <![CDATA[
             THIS SHOULD ALSO BE REMOVED
             ]]>THAT CDATA IS REMOVED.</p>
       </sec>


### PR DESCRIPTION
Addresses issue #110 

The regex meant to remove all PIs (Processing Instructions) which are of the form `<?tag ?>` was failing for at least some CDATA tags in PI form that contained a greater than symbol. This would then lead to errors such as "Invalid HTML tag name", "Invalid tag name", "Empty tag name", and "Invalid namespace URI" because of less than symbols that failed to get removed within the CDATA latex.  This occurred in parsers ("html5lib", "html.parser", "lxml-html", "direct-lxml-html"), while parsers ("lxml-xml", "direct-lxml-xml") were able to handle this type of issue and produce the correct output. 

An example can be seen in 2019InvPr..35l5002Z:
`<disp-formula><tex-math><?CDATA \begin{align*} \newcommand{\e}{{\rm e}} \displaystyle \frac{\Gamma'(1-\bar\alpha(t))}{\Gamma(1-\alpha(t))}-\ln(t-s)>Q_0 > 0,~0<s<t,~t\in (0,\varepsilon_4].\nonumber \end{align*} ?></tex-math><mml:math><mml:mstyle displaystyle="true"><mml:mtable columnalign="left" columnspacing='1'><mml:mtr><mml:mtd><mml:mstyle displaystyle="true"><mml:mfrac><mml:mrow><mml:msup><mml:mi mathvariant="normal">&#x0393;</mml:mi><mml:mo>&#x2032;</mml:mo></mml:msup><mml:mo stretchy="false">(</mml:mo><mml:mn>1</mml:mn><mml:mo>&#x2212;</mml:mo><mml:mrow><mml:mstyle displaystyle="true"><mml:mover accent="true"><mml:mi>&#x03B1;</mml:mi><mml:mo stretchy="false">&macr;</mml:mo></mml:mover></mml:mstyle></mml:mrow><mml:mo stretchy="false">(</mml:mo><mml:mi>t</mml:mi><mml:mo stretchy="false">)</mml:mo><mml:mo stretchy="false">)</mml:mo></mml:mrow><mml:mrow><mml:mi mathvariant="normal">&#x0393;</mml:mi><mml:mo stretchy="false">(</mml:mo><mml:mn>1</mml:mn><mml:mo>&#x2212;</mml:mo><mml:mi>&#x03B1;</mml:mi><mml:mo stretchy="false">(</mml:mo><mml:mi>t</mml:mi><mml:mo stretchy="false">)</mml:mo><mml:mo stretchy="false">)</mml:mo></mml:mrow></mml:mfrac><mml:mo>&#x2212;</mml:mo><mml:mi>ln</mml:mi><mml:mo>&#x2061;</mml:mo><mml:mo stretchy="false">(</mml:mo><mml:mi>t</mml:mi><mml:mo>&#x2212;</mml:mo><mml:mi>s</mml:mi><mml:mo stretchy="false">)</mml:mo><mml:mo>&gt;</mml:mo><mml:msub><mml:mi>Q</mml:mi><mml:mn>0</mml:mn></mml:msub><mml:mo>&gt;</mml:mo><mml:mn>0</mml:mn><mml:mo>,</mml:mo><mml:mtext>&nbsp;</mml:mtext><mml:mn>0</mml:mn><mml:mo>&lt;</mml:mo><mml:mi>s</mml:mi><mml:mo>&lt;</mml:mo><mml:mi>t</mml:mi><mml:mo>,</mml:mo><mml:mtext>&nbsp;</mml:mtext><mml:mi>t</mml:mi><mml:mo>&#x2208;</mml:mo><mml:mo stretchy="false">(</mml:mo><mml:mn>0</mml:mn><mml:mo>,</mml:mo><mml:msub><mml:mi>&#x03B5;</mml:mi><mml:mn>4</mml:mn></mml:msub><mml:mo stretchy="false">]</mml:mo><mml:mo>.</mml:mo></mml:mstyle></mml:mtd></mml:mtr></mml:mtable></mml:mstyle></mml:math><graphic xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="ipab3aa3eqn033.gif"/></disp-formula>`