### PR TITLE
For XML extraction, change default to translate unprintable Unicode chars

### DIFF
--- a/adsft/extraction.py
+++ b/adsft/extraction.py
@@ -857,7 +857,7 @@ class StandardExtractorXML(object):
 
         return data_inner
 
-    def extract_multi_content(self, translate=False, decode=False, preferred_parser_names=None):
+    def extract_multi_content(self, translate=False, decode=True, preferred_parser_names=None):
         """
         Extracts full text content from the XML article specified. It also
         extracts any content specified in settings.py. It expects that the user

--- a/adsft/extraction.py
+++ b/adsft/extraction.py
@@ -857,7 +857,7 @@ class StandardExtractorXML(object):
 
         return data_inner
 
-    def extract_multi_content(self, translate=False, decode=True, preferred_parser_names=None):
+    def extract_multi_content(self, translate=True, decode=False, preferred_parser_names=None):
         """
         Extracts full text content from the XML article specified. It also
         extracts any content specified in settings.py. It expects that the user


### PR DESCRIPTION
For XML extraction, the default was `translate=false` so unprintable Unicode characters were not getting replaced. This was in place since the beginning of the fulltext pipeline and is now causing issues. Updated default to true, can change at call time if necessary.